### PR TITLE
adds helper text when user does not have auth-provider setup in kubecfg

### DIFF
--- a/kubeconfig/auth.go
+++ b/kubeconfig/auth.go
@@ -18,7 +18,7 @@ func FindCurrentAuthInfo(config *api.Config) *api.AuthInfo {
 
 func ToOIDCAuthProviderConfig(authInfo *api.AuthInfo) (*OIDCAuthProviderConfig, error) {
 	if authInfo.AuthProvider == nil {
-		return nil, fmt.Errorf("auth-provider is not set")
+		return nil, fmt.Errorf("auth-provider is not set, did you setup kubectl as listed here: https://github.com/int128/kubelogin#3-setup-kubectl")
 	}
 	if authInfo.AuthProvider.Name != "oidc" {
 		return nil, fmt.Errorf("auth-provider `%s` is not supported", authInfo.AuthProvider.Name)


### PR DESCRIPTION
First off, well done. This is really well written and flows beautifully. I got stuck a bit when using the tool so I thought I'd add some helper text in case others run into the same issue.

Basically, if a User doesn't have `auth-provider` set in kubecfg, redirect them to your well-written prerequisites page.