### PR TITLE
Add support of OIDC CA certificate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
       - run: go get github.com/golang/lint/golint
       - run: golint
       - run: go build -v
+      - run: make -C integration-test/testdata
       - run: go test -v ./...
 
   release:

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,7 @@ indent_size = 2
 [*.go]
 indent_style = tab
 indent_size = 4
+
+[Makefile]
+indent_style = tab
+indent_size = 4

--- a/README.md
+++ b/README.md
@@ -173,15 +173,24 @@ Run `kubelogin` and make sure you can access to the cluster.
 See the previous section for details.
 
 
-## Tips
+## Configuration
 
-### Config file
+### Kubeconfig
 
 You can set the environment variable `KUBECONFIG` to point the config file.
 Default to `~/.kube/config`.
 
 ```sh
 export KUBECONFIG="$PWD/.kubeconfig"
+```
+
+### OpenID Connect Provider CA Certificate
+
+You can specify the CA certificate of your OpenID Connect provider by [`idp-certificate-authority` or `idp-certificate-authority-data` in the kubeconfig](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#using-kubectl).
+
+```sh
+kubectl config set-credentials CLUSTER_NAME \
+  --auth-provider-arg idp-certificate-authority=$PWD/ca.crt
 ```
 
 ### Setup script

--- a/integration-test/auth.go
+++ b/integration-test/auth.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"math/big"
 	"net/http"
+	"testing"
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
@@ -29,7 +30,7 @@ type AuthHandler struct {
 }
 
 // NewAuthHandler returns a new AuthHandler.
-func NewAuthHandler(issuer string) *AuthHandler {
+func NewAuthHandler(t *testing.T, issuer string) *AuthHandler {
 	h := &AuthHandler{
 		Issuer:        issuer,
 		AuthCode:      "0b70006b-f62a-4438-aba5-c0b96775d8e5",
@@ -44,11 +45,11 @@ func NewAuthHandler(issuer string) *AuthHandler {
 	})
 	k, err := rsa.GenerateKey(rand.Reader, 1024)
 	if err != nil {
-		log.Fatal(err)
+		t.Fatalf("Could not generate a key pair: %s", err)
 	}
 	h.IDToken, err = token.SignedString(k)
 	if err != nil {
-		log.Fatal(err)
+		t.Fatalf("Could not generate an ID token: %s", err)
 	}
 	h.PrivateKey.E = base64.RawURLEncoding.EncodeToString(big.NewInt(int64(k.E)).Bytes())
 	h.PrivateKey.N = base64.RawURLEncoding.EncodeToString(k.N.Bytes())

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -2,60 +2,159 @@ package integration
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
 	"io/ioutil"
 	"net/http"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/int128/kubelogin/cli"
 )
 
-type configuration struct {
-	Issuer string
-}
+const caCert = "testdata/authserver-ca.crt"
+const tlsCert = "testdata/authserver.crt"
+const tlsKey = "testdata/authserver.key"
 
 func Test(t *testing.T) {
-	conf := configuration{
-		Issuer: "http://localhost:9000",
-	}
+	ctx := context.Background()
 	authServer := &http.Server{
 		Addr:    "localhost:9000",
-		Handler: NewAuthHandler(conf.Issuer),
+		Handler: NewAuthHandler(t, "http://localhost:9000"),
 	}
-	defer authServer.Shutdown(context.Background())
-	kubeconfig := createKubeconfig(t, conf.Issuer)
+	defer authServer.Shutdown(ctx)
+	kubeconfig := createKubeconfig(t, &kubeconfigValues{
+		Issuer: "http://localhost:9000",
+	})
 	defer os.Remove(kubeconfig)
 
-	go func() {
-		if err := authServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			t.Error(err)
-		}
-	}()
-	go func() {
-		time.Sleep(100 * time.Millisecond)
-		res, err := http.Get("http://localhost:8000/")
-		if err != nil {
-			t.Error(err)
-		}
-		if res.StatusCode != 200 {
-			t.Errorf("StatusCode wants 200 but %d: res=%+v", res.StatusCode, res)
-		}
-	}()
-	c := cli.CLI{KubeConfig: kubeconfig}
-	if err := c.Run(); err != nil {
+	go listenAndServe(t, authServer)
+	go authenticate(t, &tls.Config{})
+
+	c := cli.CLI{
+		KubeConfig: kubeconfig,
+	}
+	if err := c.Run(ctx); err != nil {
 		t.Fatal(err)
 	}
+	verifyKubeconfig(t, kubeconfig)
+}
 
-	b, err := ioutil.ReadFile(kubeconfig)
+func TestWithSkipTLSVerify(t *testing.T) {
+	ctx := context.Background()
+	authServer := &http.Server{
+		Addr:    "localhost:9000",
+		Handler: NewAuthHandler(t, "https://localhost:9000"),
+	}
+	defer authServer.Shutdown(ctx)
+	kubeconfig := createKubeconfig(t, &kubeconfigValues{
+		Issuer: "https://localhost:9000",
+	})
+	defer os.Remove(kubeconfig)
+
+	go listenAndServeTLS(t, authServer)
+	go authenticate(t, &tls.Config{InsecureSkipVerify: true})
+
+	c := cli.CLI{
+		KubeConfig:    kubeconfig,
+		SkipTLSVerify: true,
+	}
+	if err := c.Run(ctx); err != nil {
+		t.Fatal(err)
+	}
+	verifyKubeconfig(t, kubeconfig)
+}
+
+func TestWithCACert(t *testing.T) {
+	ctx := context.Background()
+	authServer := &http.Server{
+		Addr:    "localhost:9000",
+		Handler: NewAuthHandler(t, "https://localhost:9000"),
+	}
+	defer authServer.Shutdown(ctx)
+	kubeconfig := createKubeconfig(t, &kubeconfigValues{
+		Issuer:                  "https://localhost:9000",
+		IDPCertificateAuthority: caCert,
+	})
+	defer os.Remove(kubeconfig)
+
+	go listenAndServeTLS(t, authServer)
+	go authenticate(t, &tls.Config{RootCAs: loadCACert(t)})
+
+	c := cli.CLI{
+		KubeConfig: kubeconfig,
+	}
+	if err := c.Run(ctx); err != nil {
+		t.Fatal(err)
+	}
+	verifyKubeconfig(t, kubeconfig)
+}
+
+func TestWithCACertData(t *testing.T) {
+	ctx := context.Background()
+	authServer := &http.Server{
+		Addr:    "localhost:9000",
+		Handler: NewAuthHandler(t, "https://localhost:9000"),
+	}
+	defer authServer.Shutdown(ctx)
+	b, err := ioutil.ReadFile(caCert)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Index(string(b), "id-token: ey") == -1 {
-		t.Errorf("kubeconfig wants id-token but %s", string(b))
+	kubeconfig := createKubeconfig(t, &kubeconfigValues{
+		Issuer: "https://localhost:9000",
+		IDPCertificateAuthorityData: base64.StdEncoding.EncodeToString(b),
+	})
+	defer os.Remove(kubeconfig)
+
+	go listenAndServeTLS(t, authServer)
+	go authenticate(t, &tls.Config{RootCAs: loadCACert(t)})
+
+	c := cli.CLI{
+		KubeConfig: kubeconfig,
 	}
-	if strings.Index(string(b), "refresh-token: 44df4c82-5ce7-4260-b54d-1da0d396ef2a") == -1 {
-		t.Errorf("kubeconfig wants refresh-token but %s", string(b))
+	if err := c.Run(ctx); err != nil {
+		t.Fatal(err)
+	}
+	verifyKubeconfig(t, kubeconfig)
+}
+
+func authenticate(t *testing.T, tlsConfig *tls.Config) {
+	t.Helper()
+	time.Sleep(100 * time.Millisecond)
+	client := http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}
+	res, err := client.Get("http://localhost:8000/")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if res.StatusCode != 200 {
+		t.Errorf("StatusCode wants 200 but %d: res=%+v", res.StatusCode, res)
+	}
+}
+
+func loadCACert(t *testing.T) *x509.CertPool {
+	p := x509.NewCertPool()
+	b, err := ioutil.ReadFile(caCert)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !p.AppendCertsFromPEM(b) {
+		t.Fatalf("Could not AppendCertsFromPEM")
+	}
+	return p
+}
+
+func listenAndServe(t *testing.T, s *http.Server) {
+	if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		t.Fatal(err)
+	}
+}
+
+func listenAndServeTLS(t *testing.T, s *http.Server) {
+	if err := s.ListenAndServeTLS(tlsCert, tlsKey); err != nil && err != http.ErrServerClosed {
+		t.Fatal(err)
 	}
 }

--- a/integration-test/testdata/.gitignore
+++ b/integration-test/testdata/.gitignore
@@ -1,0 +1,4 @@
+/CA
+*.key
+*.csr
+*.crt

--- a/integration-test/testdata/Makefile
+++ b/integration-test/testdata/Makefile
@@ -1,0 +1,50 @@
+.PHONY: clean
+
+all: authserver.crt authserver-ca.crt
+
+clean:
+	rm -v authserver*
+
+authserver-ca.key:
+	openssl genrsa -out $@ 1024
+
+authserver-ca.csr: openssl.cnf authserver-ca.key
+	openssl req -config openssl.cnf \
+		-new \
+		-key authserver-ca.key \
+		-subj "/CN=Hello CA" \
+		-out $@
+	openssl req -noout -text -in $@
+
+authserver-ca.crt: authserver-ca.csr authserver-ca.key
+	openssl x509 -req \
+		-signkey authserver-ca.key \
+		-in authserver-ca.csr \
+		-out $@
+	openssl x509 -text -in $@
+
+authserver.key:
+	openssl genrsa -out $@ 1024
+
+authserver.csr: openssl.cnf authserver.key
+	openssl req -config openssl.cnf \
+		-new \
+		-key authserver.key \
+		-subj "/CN=localhost" \
+		-out $@
+	openssl req -noout -text -in $@
+
+authserver.crt: openssl.cnf authserver.csr authserver-ca.key authserver-ca.crt
+	rm -fr ./CA
+	mkdir -p ./CA
+	touch CA/index.txt
+	touch CA/index.txt.attr
+	echo 00 > CA/serial
+	openssl ca -config openssl.cnf \
+		-extensions v3_req \
+		-batch \
+		-cert authserver-ca.crt \
+		-keyfile authserver-ca.key \
+		-in authserver.csr \
+		-out $@
+	openssl x509 -text -in $@

--- a/integration-test/testdata/kubeconfig.yaml
+++ b/integration-test/testdata/kubeconfig.yaml
@@ -19,4 +19,10 @@ users:
         client-id: kubernetes
         client-secret: a3c508c3-73c9-42e2-ab14-487a1bf67c33
         idp-issuer-url: {{ .Issuer }}
+#{{ if .IDPCertificateAuthority }}
+        idp-certificate-authority: {{ .IDPCertificateAuthority }}
+#{{ end }}
+#{{ if .IDPCertificateAuthorityData }}
+        idp-certificate-authority-data: {{ .IDPCertificateAuthorityData }}
+#{{ end }}
       name: oidc

--- a/integration-test/testdata/openssl.cnf
+++ b/integration-test/testdata/openssl.cnf
@@ -1,0 +1,37 @@
+[ ca ]
+default_ca      = CA_default
+
+[ CA_default ]
+dir             = ./CA
+certs           = $dir
+crl_dir         = $dir
+database        = $dir/index.txt
+new_certs_dir   = $dir
+default_md      = sha256
+policy          = policy_match
+serial          = $dir/serial
+default_days    = 365
+
+[ policy_match ]
+countryName             = optional
+stateOrProvinceName     = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+
+[ req ]
+distinguished_name	= req_distinguished_name
+req_extensions = v3_req
+x509_extensions = v3_ca
+
+[ req_distinguished_name ]
+commonName			= Common Name (e.g. server FQDN or YOUR name)
+
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = DNS:localhost
+
+[ v3_ca ]
+basicConstraints = CA:true

--- a/kubeconfig/auth.go
+++ b/kubeconfig/auth.go
@@ -16,6 +16,7 @@ func FindCurrentAuthInfo(config *api.Config) *api.AuthInfo {
 	return config.AuthInfos[context.AuthInfo]
 }
 
+// ToOIDCAuthProviderConfig converts from api.AuthInfo to OIDCAuthProviderConfig.
 func ToOIDCAuthProviderConfig(authInfo *api.AuthInfo) (*OIDCAuthProviderConfig, error) {
 	if authInfo.AuthProvider == nil {
 		return nil, fmt.Errorf("auth-provider is not set, did you setup kubectl as listed here: https://github.com/int128/kubelogin#3-setup-kubectl")
@@ -26,6 +27,7 @@ func ToOIDCAuthProviderConfig(authInfo *api.AuthInfo) (*OIDCAuthProviderConfig, 
 	return (*OIDCAuthProviderConfig)(authInfo.AuthProvider), nil
 }
 
+// OIDCAuthProviderConfig represents OIDC configuration in the kubeconfig.
 type OIDCAuthProviderConfig api.AuthProviderConfig
 
 // IDPIssuerURL returns the idp-issuer-url.
@@ -43,10 +45,22 @@ func (c *OIDCAuthProviderConfig) ClientSecret() string {
 	return c.Config["client-secret"]
 }
 
+// IDPCertificateAuthority returns the idp-certificate-authority.
+func (c *OIDCAuthProviderConfig) IDPCertificateAuthority() string {
+	return c.Config["idp-certificate-authority"]
+}
+
+// IDPCertificateAuthorityData returns the idp-certificate-authority-data.
+func (c *OIDCAuthProviderConfig) IDPCertificateAuthorityData() string {
+	return c.Config["idp-certificate-authority-data"]
+}
+
+// SetIDToken replaces the id-token.
 func (c *OIDCAuthProviderConfig) SetIDToken(idToken string) {
 	c.Config["id-token"] = idToken
 }
 
+// SetRefreshToken replaces the refresh-token.
 func (c *OIDCAuthProviderConfig) SetRefreshToken(refreshToken string) {
 	c.Config["refresh-token"] = refreshToken
 }

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log"
 	"os"
 
@@ -12,7 +13,8 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	if err := c.Run(); err != nil {
+	ctx := context.Background()
+	if err := c.Run(ctx); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
This adds support to a CA certificate of an OpenID Connect provider by [`idp-certificate-authority` or `idp-certificate-authority-data` in the kubeconfig](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#using-kubectl). See #5.