### PR TITLE
Add extra-scopes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Key | Direction | Value
 `client-secret`                   | IN (Required) | Client Secret of the provider.
 `idp-certificate-authority`       | IN (Optional) | CA certificate path of the provider.
 `idp-certificate-authority-data`  | IN (Optional) | Base64 encoded CA certificate of the provider.
+`extra-scopes`                    | IN (Optional) | Scopes to request to the provider (comma separated).
 `id-token`                        | OUT | ID token got from the provider.
 `refresh-token`                   | OUT | Refresh token got from the provider.
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -70,6 +70,7 @@ func (c *CLI) Run(ctx context.Context) error {
 		Issuer:          authProvider.IDPIssuerURL(),
 		ClientID:        authProvider.ClientID(),
 		ClientSecret:    authProvider.ClientSecret(),
+		ExtraScopes:     authProvider.ExtraScopes(),
 		Client:          &http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}},
 		ServerPort:      8000,
 		SkipOpenBrowser: c.SkipOpenBrowser,

--- a/e2e/authserver/authserver.go
+++ b/e2e/authserver/authserver.go
@@ -23,6 +23,7 @@ const ServerKey = "authserver/testdata/server.key"
 // Config represents server configuration.
 type Config struct {
 	Issuer string
+	Scope  string
 	Cert   string
 	Key    string
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -37,6 +37,18 @@ func TestE2E(t *testing.T) {
 			authserver.Config{Issuer: "http://localhost:9000"},
 			&tls.Config{},
 		},
+		"ExtraScope": {
+			kubeconfigValues{
+				Issuer:      "http://localhost:9000",
+				ExtraScopes: "profile groups",
+			},
+			cli.CLI{},
+			authserver.Config{
+				Issuer: "http://localhost:9000",
+				Scope:  "profile groups openid",
+			},
+			&tls.Config{},
+		},
 		"SkipTLSVerify": {
 			kubeconfigValues{Issuer: "https://localhost:9000"},
 			cli.CLI{SkipTLSVerify: true},

--- a/e2e/kubeconfig.go
+++ b/e2e/kubeconfig.go
@@ -9,6 +9,7 @@ import (
 
 type kubeconfigValues struct {
 	Issuer                      string
+	ExtraScopes                 string
 	IDPCertificateAuthority     string
 	IDPCertificateAuthorityData string
 }

--- a/e2e/testdata/kubeconfig.yaml
+++ b/e2e/testdata/kubeconfig.yaml
@@ -19,6 +19,9 @@ users:
         client-id: kubernetes
         client-secret: a3c508c3-73c9-42e2-ab14-487a1bf67c33
         idp-issuer-url: {{ .Issuer }}
+#{{ if .ExtraScopes }}
+        extra-scopes: {{ .ExtraScopes }}
+#{{ end }}
 #{{ if .IDPCertificateAuthority }}
         idp-certificate-authority: {{ .IDPCertificateAuthority }}
 #{{ end }}

--- a/kubeconfig/auth.go
+++ b/kubeconfig/auth.go
@@ -2,6 +2,7 @@ package kubeconfig
 
 import (
 	"fmt"
+	"strings"
 
 	"k8s.io/client-go/tools/clientcmd/api"
 )
@@ -53,6 +54,14 @@ func (c *OIDCAuthProvider) IDPCertificateAuthority() string {
 // IDPCertificateAuthorityData returns the idp-certificate-authority-data.
 func (c *OIDCAuthProvider) IDPCertificateAuthorityData() string {
 	return c.Config["idp-certificate-authority-data"]
+}
+
+// ExtraScopes returns the extra-scopes.
+func (c *OIDCAuthProvider) ExtraScopes() []string {
+	if c.Config["extra-scopes"] == "" {
+		return []string{}
+	}
+	return strings.Split(c.Config["extra-scopes"], ",")
 }
 
 // SetIDToken replaces the id-token.


### PR DESCRIPTION
This supports `extra-scopes` key of `auth-server` in kubeconfig. See #8.