### PR TITLE
Fix refresh token is not set with Google IdP

### DIFF
--- a/auth/authcode.go
+++ b/auth/authcode.go
@@ -13,6 +13,7 @@ import (
 
 type authCodeFlow struct {
 	Config          *oauth2.Config
+	AuthCodeOptions []oauth2.AuthCodeOption
 	ServerPort      int  // HTTP server port
 	SkipOpenBrowser bool // skip opening browser if true
 }
@@ -41,7 +42,7 @@ func (f *authCodeFlow) getAuthCode(ctx context.Context) (string, error) {
 	server := http.Server{
 		Addr: fmt.Sprintf("localhost:%d", f.ServerPort),
 		Handler: &authCodeHandler{
-			authCodeURL: f.Config.AuthCodeURL(state),
+			authCodeURL: f.Config.AuthCodeURL(state, f.AuthCodeOptions...),
 			gotCode: func(code string, gotState string) {
 				if gotState == state {
 					codeCh <- code

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -47,6 +47,7 @@ func (c *Config) GetTokenSet(ctx context.Context) (*TokenSet, error) {
 		ServerPort:      c.ServerPort,
 		SkipOpenBrowser: c.SkipOpenBrowser,
 		Config:          oauth2Config,
+		AuthCodeOptions: []oauth2.AuthCodeOption{oauth2.AccessTypeOffline},
 	}
 	token, err := flow.getToken(ctx)
 	if err != nil {


### PR DESCRIPTION
See #11.

>To request a refresh token, add access_type=offline to the authentication request.
>https://developers.google.com/identity/protocols/OpenIDConnect#refresh-tokens