### PR TITLE
Added offline_access claim to get Mitreid to issue refresh token

### DIFF
--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -40,7 +40,7 @@ func (c *Config) GetTokenSet(ctx context.Context) (*TokenSet, error) {
 		Endpoint:     provider.Endpoint(),
 		ClientID:     c.ClientID,
 		ClientSecret: c.ClientSecret,
-		Scopes:       append(c.ExtraScopes, oidc.ScopeOpenID),
+		Scopes:       append(c.ExtraScopes, oidc.ScopeOpenID, oidc.ScopeOfflineAccess),
 		RedirectURL:  fmt.Sprintf("http://localhost:%d/", c.ServerPort),
 	}
 	flow := &authCodeFlow{


### PR DESCRIPTION
I need to include the ScopeOfflineAccess in order to get refresh tokens when using the [MITREid Connect](https://github.com/mitreid-connect) server. I haven't tried this with any other OIDC IdPs so unsure if it causes problems but in my case it allowed me to get refresh tokens with that OIDC provider.