### PR TITLE
Skip invalid CA certs instead of raising error

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ sed -i '' -e s/SCOPES/email,profile/ $KUBECONFIG
 ```
 
 
+## CA Certificates
+
+You can set your self-signed certificates for the OIDC provider (not Kubernetes API server) by `idp-certificate-authority` and `idp-certificate-authority-data` in the kubeconfig.
+
+```sh
+kubectl config set-credentials keycloak \
+  --auth-provider-arg idp-certificate-authority=$HOME/.kube/keycloak-ca.pem
+```
+
+If kubelogin could not parse the certificate, it shows a warning and skips it.
+
+
 ## Contributions
 
 This is an open source software licensed under Apache License 2.0.

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -69,10 +69,7 @@ func (c *CLI) Run(ctx context.Context) error {
 					--auth-provider-arg client-secret=YOUR_CLIENT_SECRET`,
 			err, cfg.CurrentContext)
 	}
-	tlsConfig, err := c.tlsConfig(authProvider)
-	if err != nil {
-		return fmt.Errorf("Could not configure TLS: %s", err)
-	}
+	tlsConfig := c.tlsConfig(authProvider)
 	authConfig := &auth.Config{
 		Issuer:          authProvider.IDPIssuerURL(),
 		ClientID:        authProvider.ClientID(),

--- a/cli/tls.go
+++ b/cli/tls.go
@@ -11,32 +11,47 @@ import (
 	"github.com/int128/kubelogin/kubeconfig"
 )
 
-func (c *CLI) tlsConfig(authProvider *kubeconfig.OIDCAuthProvider) (*tls.Config, error) {
+func (c *CLI) tlsConfig(authProvider *kubeconfig.OIDCAuthProvider) *tls.Config {
 	p := x509.NewCertPool()
 	if ca := authProvider.IDPCertificateAuthority(); ca != "" {
-		b, err := ioutil.ReadFile(ca)
-		if err != nil {
-			return nil, fmt.Errorf("Could not read %s: %s", ca, err)
+		if err := appendCertFile(p, ca); err != nil {
+			log.Printf("Skip CA certificate of idp-certificate-authority: %s", err)
+		} else {
+			log.Printf("Using CA certificate: %s", ca)
 		}
-		if p.AppendCertsFromPEM(b) != true {
-			return nil, fmt.Errorf("Could not append CA certificate from %s", ca)
-		}
-		log.Printf("Using CA certificate: %s", ca)
 	}
 	if ca := authProvider.IDPCertificateAuthorityData(); ca != "" {
-		b, err := base64.StdEncoding.DecodeString(ca)
-		if err != nil {
-			return nil, fmt.Errorf("Could not decode idp-certificate-authority-data: %s", err)
+		if err := appendCertData(p, ca); err != nil {
+			log.Printf("Skip CA certificate of idp-certificate-authority-data: %s", err)
+		} else {
+			log.Printf("Using CA certificate of idp-certificate-authority-data")
 		}
-		if p.AppendCertsFromPEM(b) != true {
-			return nil, fmt.Errorf("Could not append CA certificate from idp-certificate-authority-data")
-		}
-		log.Printf("Using CA certificate: idp-certificate-authority-data")
 	}
-
 	cfg := &tls.Config{InsecureSkipVerify: c.SkipTLSVerify}
 	if len(p.Subjects()) > 0 {
 		cfg.RootCAs = p
 	}
-	return cfg, nil
+	return cfg
+}
+
+func appendCertFile(p *x509.CertPool, name string) error {
+	b, err := ioutil.ReadFile(name)
+	if err != nil {
+		return fmt.Errorf("Could not read %s: %s", name, err)
+	}
+	if p.AppendCertsFromPEM(b) != true {
+		return fmt.Errorf("Could not append certificate from %s", name)
+	}
+	return nil
+}
+
+func appendCertData(p *x509.CertPool, data string) error {
+	b, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		return fmt.Errorf("Could not decode base64: %s", err)
+	}
+	if p.AppendCertsFromPEM(b) != true {
+		return fmt.Errorf("Could not append certificate")
+	}
+	return nil
 }

--- a/cli_test/e2e_test.go
+++ b/cli_test/e2e_test.go
@@ -86,6 +86,24 @@ func TestE2E(t *testing.T) {
 			},
 			&tls.Config{RootCAs: readCert(t, authserver.CACert)},
 		},
+		"InvalidCACertShouldBeSkipped": {
+			kubeconfig.Values{
+				Issuer: "http://localhost:9000",
+				IDPCertificateAuthority: "e2e_test.go",
+			},
+			cli.CLI{},
+			authserver.Config{Issuer: "http://localhost:9000"},
+			&tls.Config{},
+		},
+		"InvalidCACertDataShouldBeSkipped": {
+			kubeconfig.Values{
+				Issuer: "http://localhost:9000",
+				IDPCertificateAuthorityData: base64.StdEncoding.EncodeToString([]byte("foo")),
+			},
+			cli.CLI{},
+			authserver.Config{Issuer: "http://localhost:9000"},
+			&tls.Config{},
+		},
 	}
 
 	for name, c := range data {


### PR DESCRIPTION
This changes behavior of loading CA certificate to skip invalid certificates and show warnings. It is for some case that a user want to use `--insecure-skip-tls-verify` with invalid certificates. See also #20.