### PR TITLE
Rename plugin to kubectl oidc-login

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,12 @@ jobs:
     docker:
       - image: circleci/golang:1.11.1
     steps:
+      - run: |
+          mkdir -p ~/bin
+          echo 'export PATH="$HOME/bin:$PATH"' >> $BASH_ENV
+      - run: |
+          curl -L -o ~/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
+          chmod +x ~/bin/kubectl
       - run: go get golang.org/x/lint/golint
       - run: go get github.com/mitchellh/gox
       - run: go get github.com/tcnksm/ghr
@@ -13,7 +19,7 @@ jobs:
       # workaround for https://github.com/golang/go/issues/27925
       - run: sed -e '/^k8s.io\/client-go /d' -i go.sum
       - run: make check
-      - run: make
+      - run: make run
       - run: |
           if [ "$CIRCLE_TAG" ]; then
             make release

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 TARGET := kubelogin
+TARGET_PLUGIN := kubectl-oidc_login
 OSARCH := darwin/amd64 linux/amd64 windows/amd64
 CIRCLE_TAG ?= snapshot
 
-.PHONY: check release_bin release_homebrew release clean
+.PHONY: check run release_bin release_homebrew release clean
 
 all: dist/$(TARGET)
 
@@ -14,6 +15,12 @@ check:
 
 dist/$(TARGET): $(wildcard *.go)
 	go build -o $@ -ldflags '-X main.version=$(CIRCLE_TAG)'
+
+dist/$(TARGET_PLUGIN): dist/$(TARGET)
+	ln -s $(TARGET) $@
+
+run: dist/$(TARGET_PLUGIN)
+	-PATH=dist:$(PATH) kubectl oidc-login --help
 
 dist/bin:
 	gox --osarch '$(OSARCH)' -output 'dist/bin/$(TARGET)_{{.OS}}_{{.Arch}}'

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ After initial setup or when the token has been expired, just run:
 2018/08/27 15:03:09 Updated /home/user/.kube/config
 ```
 
-or
+or run as a plugin:
 
 ```
-% kubectl login
+% kubectl oidc-login
 ```
 
 It opens the browser and you can log in to the provider.

--- a/homebrew.sh
+++ b/homebrew.sh
@@ -12,11 +12,11 @@ class Kubelogin < Formula
   sha256 "${dist_sha256}"
   def install
     bin.install "kubelogin_darwin_amd64" => "kubelogin"
-    ln_s bin/"kubelogin", bin/"kubectl-login"
+    ln_s bin/"kubelogin", bin/"kubectl-oidc_login"
   end
   test do
     system "#{bin}/kubelogin -h"
-    system "#{bin}/kubectl-login -h"
+    system "#{bin}/kubectl-oidc_login -h"
   end
 end
 EOF


### PR DESCRIPTION
This renames the plugin to `kubectl oidc-login`.

See the naming guide:
https://github.com/GoogleContainerTools/krew/blob/master/docs/NAMING_GUIDE.md