### PR TITLE
HTTPS_PROXY support for kubelogin

### DIFF
--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-  "net/url"
-  "os"
+	"net/url"
+	"os"
 
 	oidc "github.com/coreos/go-oidc"
 	"github.com/int128/oauth2cli"
@@ -33,22 +33,22 @@ type Config struct {
 // GetTokenSet retrives a token from the OIDC provider and returns a TokenSet.
 func (c *Config) GetTokenSet(ctx context.Context) (*TokenSet, error) {
 	if c.Client != nil {
-    // https://github.com/int128/kubelogin/issues/31
-    val, ok := os.LookupEnv("HTTPS_PROXY")
-    if ok {
-      proxyURL, err := url.Parse(val)
-      if err != nil {
-        log.Printf("HTTPS_PROXY %s cannot be parsed into a URL\n", val)
-      } else {
-        transport := &http.Transport{
-          Proxy: http.ProxyURL(proxyURL),
-        }
-        c.Client = &http.Client{
-          Transport: transport,
-        }
-      }
-    }
-    //
+		// https://github.com/int128/kubelogin/issues/31
+		val, ok := os.LookupEnv("HTTPS_PROXY")
+		if ok {
+			proxyURL, err := url.Parse(val)
+			if err != nil {
+				log.Printf("HTTPS_PROXY %s cannot be parsed into a URL\n", val)
+			} else {
+				transport := &http.Transport{
+					Proxy: http.ProxyURL(proxyURL),
+				}
+				c.Client = &http.Client{
+					Transport: transport,
+				}
+			}
+		}
+		//
 		ctx = context.WithValue(ctx, oauth2.HTTPClient, c.Client)
 	}
 	provider, err := oidc.NewProvider(ctx, c.Issuer)

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+  "net/url"
+  "os"
 
 	oidc "github.com/coreos/go-oidc"
 	"github.com/int128/oauth2cli"

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -31,6 +31,22 @@ type Config struct {
 // GetTokenSet retrives a token from the OIDC provider and returns a TokenSet.
 func (c *Config) GetTokenSet(ctx context.Context) (*TokenSet, error) {
 	if c.Client != nil {
+    // https://github.com/int128/kubelogin/issues/31
+    val, ok := os.LookupEnv("HTTPS_PROXY")
+    if ok {
+      proxyURL, err := url.Parse(val)
+      if err != nil {
+        log.Printf("HTTPS_PROXY %s cannot be parsed into a URL\n", val)
+      } else {
+        transport := &http.Transport{
+          Proxy: http.ProxyURL(proxyURL),
+        }
+        c.Client = &http.Client{
+          Transport: transport,
+        }
+      }
+    }
+    //
 		ctx = context.WithValue(ctx, oauth2.HTTPClient, c.Client)
 	}
 	provider, err := oidc.NewProvider(ctx, c.Issuer)


### PR DESCRIPTION
#31. The code checks whether HTTPS_PROXY environmental variable is set or not and initializes a Transport which is to be used in the Client.