### PR TITLE
Add yaml for Krew installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ run: $(TARGET_PLUGIN)
 	-PATH=.:$(PATH) kubectl oidc-login --help
 
 dist:
-	VERSION=$(CIRCLE_TAG) goxzst -d dist/gh/ -o "$(TARGET)" -t "kubelogin.rb" -- -ldflags "$(LDFLAGS)"
+	VERSION=$(CIRCLE_TAG) goxzst -d dist/gh/ -o "$(TARGET)" -t "kubelogin.rb oidc-login.yaml" -- -ldflags "$(LDFLAGS)"
 	mv dist/gh/kubelogin.rb dist/
 
 release: dist

--- a/oidc-login.yaml
+++ b/oidc-login.yaml
@@ -1,0 +1,57 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: oidc-login
+spec:
+  shortDescription: Login for OpenID Connect authentication
+  description: |
+    This plugin gets a token from the OIDC provider and writes it to the kubeconfig.
+
+    Just run:
+      % kubectl oidc-login
+
+    It opens the browser and you can log in to the provider.
+    After authentication, it gets an ID token and refresh token and writes them to the kubeconfig.
+
+  caveats: |
+    You need to setup the following components:
+      * OIDC provider
+      * Kubernetes API server
+      * Role for your group or user
+      * kubectl authentication
+
+    See https://github.com/int128/kubelogin for more.
+
+  homepage: https://github.com/int128/kubelogin
+  version: {{ env "VERSION" }}
+  platforms:
+    - uri: https://github.com/int128/kubelogin/releases/download/{{ env "VERSION" }}/kubelogin_linux_amd64.zip
+      sha256: "{{ .linux_amd64_zip_sha256 }}"
+      bin: kubelogin
+      files:
+        - from: "kubelogin"
+          to: "."
+      selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+    - uri: https://github.com/int128/kubelogin/releases/download/{{ env "VERSION" }}/kubelogin_darwin_amd64.zip
+      sha256: "{{ .darwin_amd64_zip_sha256 }}"
+      bin: kubelogin
+      files:
+        - from: "kubelogin"
+          to: "."
+      selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+    - uri: https://github.com/int128/kubelogin/releases/download/{{ env "VERSION" }}/kubelogin_windows_amd64.zip
+      sha256: "{{ .windows_amd64_zip_sha256 }}"
+      bin: kubelogin.exe
+      files:
+        - from: "kubelogin.exe"
+          to: "."
+      selector:
+        matchLabels:
+          os: windows
+          arch: amd64


### PR DESCRIPTION
This adds the yaml for Krew installation. See #34.

This has been tested on local but not tested with actual GitHub Releases.

```
% kubectl krew install --manifest dist/gh/oidc-login.yaml --archive dist/gh/kubelogin_darwin_amd64.zip
Installing plugin: oidc-login
CAVEATS:
\
 |  You need to setup the following components:
 |    * OIDC provider
 |    * Kubernetes API server
 |    * Role for your group or user
 |    * kubectl authentication
 |
 |  See https://github.com/int128/kubelogin for more.
/
Installed plugin: oidc-login

% kubectl oidc-login -h

% kubectl krew remove oidc-login
```