### PR TITLE
Replace with errors.Errorf() and errors.Wrapf()

### DIFF
--- a/cli/tls.go
+++ b/cli/tls.go
@@ -4,11 +4,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
-	"fmt"
 	"io/ioutil"
 	"log"
 
 	"github.com/int128/kubelogin/kubeconfig"
+	"github.com/pkg/errors"
 )
 
 func (c *CLI) tlsConfig(authProvider *kubeconfig.OIDCAuthProvider) *tls.Config {
@@ -37,10 +37,10 @@ func (c *CLI) tlsConfig(authProvider *kubeconfig.OIDCAuthProvider) *tls.Config {
 func appendCertFile(p *x509.CertPool, name string) error {
 	b, err := ioutil.ReadFile(name)
 	if err != nil {
-		return fmt.Errorf("Could not read %s: %s", name, err)
+		return errors.Wrapf(err, "could not read %s", name)
 	}
 	if p.AppendCertsFromPEM(b) != true {
-		return fmt.Errorf("Could not append certificate from %s", name)
+		return errors.Errorf("could not append certificate from %s", name)
 	}
 	return nil
 }
@@ -48,10 +48,10 @@ func appendCertFile(p *x509.CertPool, name string) error {
 func appendCertData(p *x509.CertPool, data string) error {
 	b, err := base64.StdEncoding.DecodeString(data)
 	if err != nil {
-		return fmt.Errorf("Could not decode base64: %s", err)
+		return errors.Wrapf(err, "could not decode base64")
 	}
 	if p.AppendCertsFromPEM(b) != true {
-		return fmt.Errorf("Could not append certificate")
+		return errors.Errorf("could not append certificate")
 	}
 	return nil
 }

--- a/cli_test/authserver/handler.go
+++ b/cli_test/authserver/handler.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/pkg/errors"
 )
 
 type handler struct {
@@ -89,7 +90,7 @@ func (h *handler) serveHTTP(w http.ResponseWriter, r *http.Request) error {
 		// http://openid.net/specs/openid-connect-core-1_0.html#AuthResponse
 		q := r.URL.Query()
 		if h.Scope != q.Get("scope") {
-			return fmt.Errorf("scope wants %s but %s", h.Scope, q.Get("scope"))
+			return errors.Errorf("scope wants %s but %s", h.Scope, q.Get("scope"))
 		}
 		to := fmt.Sprintf("%s?state=%s&code=%s", q.Get("redirect_uri"), q.Get("state"), h.authCode)
 		http.Redirect(w, r, to, 302)
@@ -100,7 +101,7 @@ func (h *handler) serveHTTP(w http.ResponseWriter, r *http.Request) error {
 			return err
 		}
 		if h.authCode != r.Form.Get("code") {
-			return fmt.Errorf("code wants %s but %s", h.authCode, r.Form.Get("code"))
+			return errors.Errorf("code wants %s but %s", h.authCode, r.Form.Get("code"))
 		}
 		w.Header().Add("Content-Type", "application/json")
 		if err := h.token.Execute(w, h); err != nil {

--- a/cli_test/e2e_test.go
+++ b/cli_test/e2e_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -15,6 +14,7 @@ import (
 	"github.com/int128/kubelogin/cli"
 	"github.com/int128/kubelogin/cli_test/authserver"
 	"github.com/int128/kubelogin/cli_test/kubeconfig"
+	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -75,7 +75,7 @@ func TestE2E(t *testing.T) {
 		},
 		"CACertData": {
 			kubeconfig.Values{
-				Issuer: "https://localhost:9000",
+				Issuer:                      "https://localhost:9000",
 				IDPCertificateAuthorityData: base64.StdEncoding.EncodeToString(read(t, authserver.CACert)),
 			},
 			cli.CLI{},
@@ -88,7 +88,7 @@ func TestE2E(t *testing.T) {
 		},
 		"InvalidCACertShouldBeSkipped": {
 			kubeconfig.Values{
-				Issuer: "http://localhost:9000",
+				Issuer:                  "http://localhost:9000",
 				IDPCertificateAuthority: "e2e_test.go",
 			},
 			cli.CLI{},
@@ -97,7 +97,7 @@ func TestE2E(t *testing.T) {
 		},
 		"InvalidCACertDataShouldBeSkipped": {
 			kubeconfig.Values{
-				Issuer: "http://localhost:9000",
+				Issuer:                      "http://localhost:9000",
 				IDPCertificateAuthorityData: base64.StdEncoding.EncodeToString([]byte("foo")),
 			},
 			cli.CLI{},
@@ -139,10 +139,10 @@ func openBrowserRequest(tlsConfig *tls.Config) error {
 	client := http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}
 	res, err := client.Get("http://localhost:8000/")
 	if err != nil {
-		return fmt.Errorf("Could not send a request: %s", err)
+		return errors.Wrapf(err, "could not send a request")
 	}
 	if res.StatusCode != 200 {
-		return fmt.Errorf("StatusCode wants 200 but %d", res.StatusCode)
+		return errors.Errorf("StatusCode wants 200 but %d", res.StatusCode)
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/stretchr/testify v1.3.0 // indirect

--- a/kubeconfig/auth.go
+++ b/kubeconfig/auth.go
@@ -1,9 +1,9 @@
 package kubeconfig
 
 import (
-	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
 
@@ -13,17 +13,17 @@ import (
 func FindOIDCAuthProvider(config *api.Config) (*OIDCAuthProvider, error) {
 	context := config.Contexts[config.CurrentContext]
 	if context == nil {
-		return nil, fmt.Errorf("context %s does not exist", config.CurrentContext)
+		return nil, errors.Errorf("context %s does not exist", config.CurrentContext)
 	}
 	authInfo := config.AuthInfos[context.AuthInfo]
 	if authInfo == nil {
-		return nil, fmt.Errorf("auth-info %s does not exist", context.AuthInfo)
+		return nil, errors.Errorf("auth-info %s does not exist", context.AuthInfo)
 	}
 	if authInfo.AuthProvider == nil {
-		return nil, fmt.Errorf("auth-provider is not set")
+		return nil, errors.Errorf("auth-provider is not set")
 	}
 	if authInfo.AuthProvider.Name != "oidc" {
-		return nil, fmt.Errorf("auth-provider name is %s but must be oidc", authInfo.AuthProvider.Name)
+		return nil, errors.Errorf("auth-provider name is %s but must be oidc", authInfo.AuthProvider.Name)
 	}
 	return (*OIDCAuthProvider)(authInfo.AuthProvider), nil
 }


### PR DESCRIPTION
This replaces error handling with `errors.Errorf()` and `errors.Wrapf()` for stacktraces.