### PR TITLE
Add support of HTTP_PROXY, HTTPS_PROXY and NO_PROXY

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ kubectl config set-credentials keycloak \
 If kubelogin could not parse the certificate, it shows a warning and skips it.
 
 
+### HTTP Proxy
+
+You can set the following environment variables if you are behind a proxy: `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY`.
+See also [net/http#ProxyFromEnvironment](https://golang.org/pkg/net/http/#ProxyFromEnvironment).
+
+
 ## Contributions
 
 This is an open source software licensed under Apache License 2.0.

--- a/adaptors/http.go
+++ b/adaptors/http.go
@@ -5,10 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"io/ioutil"
-	"log"
 	"net/http"
-	"net/url"
-	"os"
 
 	"github.com/int128/kubelogin/adaptors/interfaces"
 	"github.com/pkg/errors"
@@ -27,21 +24,12 @@ func (*HTTP) NewClientConfig() adaptors.HTTPClientConfig {
 }
 
 func (*HTTP) NewClient(config adaptors.HTTPClientConfig) (*http.Client, error) {
-	transport := &http.Transport{}
-	//TODO: replace with http.ProxyFromEnvironmentURL or go-ieproxy
-	// https://github.com/int128/kubelogin/issues/31
-	val, ok := os.LookupEnv("HTTPS_PROXY")
-	if ok {
-		proxyURL, err := url.Parse(val)
-		if err != nil {
-			log.Printf("HTTPS_PROXY %s cannot be parsed into a URL\n", val)
-		} else {
-			transport.Proxy = http.ProxyURL(proxyURL)
-		}
-	}
-	//
-	transport.TLSClientConfig = config.TLSConfig()
-	return &http.Client{Transport: transport}, nil
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: config.TLSConfig(),
+			Proxy:           http.ProxyFromEnvironment,
+		},
+	}, nil
 }
 
 type httpClientConfig struct {


### PR DESCRIPTION
This adds support of the environment variables: `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY`.
It is enhancement of #41.