### PR TITLE
Skip login if kubeconfig has valid ID token

### DIFF
--- a/adaptors/interfaces/adaptors.go
+++ b/adaptors/interfaces/adaptors.go
@@ -35,6 +35,7 @@ type HTTPClientConfig interface {
 
 type OIDC interface {
 	Authenticate(ctx context.Context, in OIDCAuthenticateIn) (*OIDCAuthenticateOut, error)
+	VerifyIDToken(ctx context.Context, in OIDCVerifyTokenIn) (*oidc.IDToken, error)
 }
 
 type OIDCAuthenticateIn struct {
@@ -51,6 +52,13 @@ type OIDCAuthenticateOut struct {
 	VerifiedIDToken *oidc.IDToken
 	IDToken         string
 	RefreshToken    string
+}
+
+type OIDCVerifyTokenIn struct {
+	IDToken  string
+	Issuer   string
+	ClientID string
+	Client   *http.Client
 }
 
 type Logger interface {

--- a/adaptors/mock_adaptors/mock_adaptors.go
+++ b/adaptors/mock_adaptors/mock_adaptors.go
@@ -7,6 +7,7 @@ package mock_adaptors
 import (
 	context "context"
 	tls "crypto/tls"
+	go_oidc "github.com/coreos/go-oidc"
 	gomock "github.com/golang/mock/gomock"
 	interfaces "github.com/int128/kubelogin/adaptors/interfaces"
 	api "k8s.io/client-go/tools/clientcmd/api"
@@ -213,4 +214,17 @@ func (m *MockOIDC) Authenticate(arg0 context.Context, arg1 interfaces.OIDCAuthen
 // Authenticate indicates an expected call of Authenticate
 func (mr *MockOIDCMockRecorder) Authenticate(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Authenticate", reflect.TypeOf((*MockOIDC)(nil).Authenticate), arg0, arg1)
+}
+
+// VerifyIDToken mocks base method
+func (m *MockOIDC) VerifyIDToken(arg0 context.Context, arg1 interfaces.OIDCVerifyTokenIn) (*go_oidc.IDToken, error) {
+	ret := m.ctrl.Call(m, "VerifyIDToken", arg0, arg1)
+	ret0, _ := ret[0].(*go_oidc.IDToken)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// VerifyIDToken indicates an expected call of VerifyIDToken
+func (mr *MockOIDCMockRecorder) VerifyIDToken(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyIDToken", reflect.TypeOf((*MockOIDC)(nil).VerifyIDToken), arg0, arg1)
 }

--- a/adaptors/oidc.go
+++ b/adaptors/oidc.go
@@ -54,3 +54,19 @@ func (*OIDC) Authenticate(ctx context.Context, in adaptors.OIDCAuthenticateIn) (
 		RefreshToken:    token.RefreshToken,
 	}, nil
 }
+
+func (*OIDC) VerifyIDToken(ctx context.Context, in adaptors.OIDCVerifyTokenIn) (*oidc.IDToken, error) {
+	if in.Client != nil {
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, in.Client)
+	}
+	provider, err := oidc.NewProvider(ctx, in.Issuer)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not discovery the OIDC issuer")
+	}
+	verifier := provider.Verifier(&oidc.Config{ClientID: in.ClientID})
+	verifiedIDToken, err := verifier.Verify(ctx, in.IDToken)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not verify the id_token")
+	}
+	return verifiedIDToken, nil
+}

--- a/adaptors_test/authserver/authserver.go
+++ b/adaptors_test/authserver/authserver.go
@@ -1,6 +1,7 @@
 package authserver
 
 import (
+	"crypto/rsa"
 	"net/http"
 	"testing"
 )
@@ -22,14 +23,16 @@ const ServerKey = "authserver/testdata/server.key"
 
 // Config represents server configuration.
 type Config struct {
-	Issuer string
-	Scope  string
-	Cert   string
-	Key    string
+	Issuer         string
+	Scope          string
+	Cert           string
+	Key            string
+	IDToken        string
+	IDTokenKeyPair *rsa.PrivateKey
 }
 
 // Start starts a HTTP server.
-func (c *Config) Start(t *testing.T) *http.Server {
+func Start(t *testing.T, c Config) *http.Server {
 	s := &http.Server{
 		Addr:    Addr,
 		Handler: newHandler(t, c),

--- a/adaptors_test/keys/keys.go
+++ b/adaptors_test/keys/keys.go
@@ -1,0 +1,34 @@
+package keys
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+func New(t *testing.T) Keys {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatalf("Could not generate a key pair: %s", err)
+	}
+	return Keys{
+		IDTokenKeyPair: k,
+	}
+}
+
+type Keys struct {
+	IDTokenKeyPair *rsa.PrivateKey // a key pair for signing ID tokens
+}
+
+func (c *Keys) SignClaims(t *testing.T, claims jwt.Claims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	s, err := token.SignedString(c.IDTokenKeyPair)
+	if err != nil {
+		t.Fatalf("Could not sign the claims: %s", err)
+	}
+	return s
+}

--- a/adaptors_test/kubeconfig/testdata/kubeconfig.yaml
+++ b/adaptors_test/kubeconfig/testdata/kubeconfig.yaml
@@ -28,4 +28,7 @@ users:
 #{{ if .IDPCertificateAuthorityData }}
         idp-certificate-authority-data: {{ .IDPCertificateAuthorityData }}
 #{{ end }}
+#{{ if .IDToken }}
+        id-token: {{ .IDToken }}
+#{{ end }}
       name: oidc

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.3.0 // indirect
-	gopkg.in/yaml.v2 v2.2.2 // indirect
+	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/api v0.0.0-20190222213804-5cb15d344471 // indirect
 	k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628 // indirect
 	k8s.io/client-go v10.0.0+incompatible

--- a/kubeconfig/auth.go
+++ b/kubeconfig/auth.go
@@ -64,6 +64,11 @@ func (c *OIDCAuthProvider) ExtraScopes() []string {
 	return strings.Split(c.Config["extra-scopes"], ",")
 }
 
+// IDToken returns the id-token.
+func (c *OIDCAuthProvider) IDToken() string {
+	return c.Config["id-token"]
+}
+
 // SetIDToken replaces the id-token.
 func (c *OIDCAuthProvider) SetIDToken(idToken string) {
 	c.Config["id-token"] = idToken


### PR DESCRIPTION
This add the feature to skip login if the kubeconfig already has a valid ID token. It will fix #35.

```
% kubelogin
2019/04/09 13:59:38 Using current-context: hello.k8s.local
2019/04/09 13:59:39 You already have a valid ID token (until 2019-04-09 14:33:44 +0900 JST)
```