### PR TITLE
Change expected binary name to kubelogin

### DIFF
--- a/kubelogin.rb
+++ b/kubelogin.rb
@@ -5,7 +5,7 @@ class Kubelogin < Formula
   version "{{ env "VERSION" }}"
   sha256 "{{ .darwin_amd64_zip_sha256 }}"
   def install
-    bin.install "kubelogin_darwin_amd64" => "kubelogin"
+    bin.install "kubelogin" => "kubelogin"
     ln_s bin/"kubelogin", bin/"kubectl-oidc_login"
   end
   test do


### PR DESCRIPTION
Per the request on [homebrew-kubelogin](https://github.com/int128/homebrew-kubelogin/pull/1), here's a corresponding change for kubelogin.rb. 

I'm less confident in this change, because I'm not sure about the relationship between this file and the homebrew tap at github.com/int128/homebrew-kubelogin, so I'm unsure how to test this one. I also haven't figured out where the `kubelogin_darwin_amd64` filename originated. Is it part of build tooling not included in the repo?