### PR TITLE
Refactor: use dedicated Logger on authentication callback

### DIFF
--- a/adaptors/interfaces/adaptors.go
+++ b/adaptors/interfaces/adaptors.go
@@ -34,7 +34,7 @@ type HTTPClientConfig interface {
 }
 
 type OIDC interface {
-	Authenticate(ctx context.Context, in OIDCAuthenticateIn) (*OIDCAuthenticateOut, error)
+	Authenticate(ctx context.Context, in OIDCAuthenticateIn, cb OIDCAuthenticateCallback) (*OIDCAuthenticateOut, error)
 	VerifyIDToken(ctx context.Context, in OIDCVerifyTokenIn) (*oidc.IDToken, error)
 }
 
@@ -46,6 +46,10 @@ type OIDCAuthenticateIn struct {
 	Client          *http.Client // HTTP client for oidc and oauth2
 	LocalServerPort int          // HTTP server port
 	SkipOpenBrowser bool         // skip opening browser if true
+}
+
+type OIDCAuthenticateCallback struct {
+	ShowLocalServerURL func(url string)
 }
 
 type OIDCAuthenticateOut struct {

--- a/adaptors/mock_adaptors/mock_adaptors.go
+++ b/adaptors/mock_adaptors/mock_adaptors.go
@@ -204,16 +204,16 @@ func (m *MockOIDC) EXPECT() *MockOIDCMockRecorder {
 }
 
 // Authenticate mocks base method
-func (m *MockOIDC) Authenticate(arg0 context.Context, arg1 interfaces.OIDCAuthenticateIn) (*interfaces.OIDCAuthenticateOut, error) {
-	ret := m.ctrl.Call(m, "Authenticate", arg0, arg1)
+func (m *MockOIDC) Authenticate(arg0 context.Context, arg1 interfaces.OIDCAuthenticateIn, arg2 interfaces.OIDCAuthenticateCallback) (*interfaces.OIDCAuthenticateOut, error) {
+	ret := m.ctrl.Call(m, "Authenticate", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*interfaces.OIDCAuthenticateOut)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Authenticate indicates an expected call of Authenticate
-func (mr *MockOIDCMockRecorder) Authenticate(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Authenticate", reflect.TypeOf((*MockOIDC)(nil).Authenticate), arg0, arg1)
+func (mr *MockOIDCMockRecorder) Authenticate(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Authenticate", reflect.TypeOf((*MockOIDC)(nil).Authenticate), arg0, arg1, arg2)
 }
 
 // VerifyIDToken mocks base method

--- a/adaptors/oidc.go
+++ b/adaptors/oidc.go
@@ -16,7 +16,7 @@ func NewOIDC() adaptors.OIDC {
 
 type OIDC struct{}
 
-func (*OIDC) Authenticate(ctx context.Context, in adaptors.OIDCAuthenticateIn) (*adaptors.OIDCAuthenticateOut, error) {
+func (*OIDC) Authenticate(ctx context.Context, in adaptors.OIDCAuthenticateIn, cb adaptors.OIDCAuthenticateCallback) (*adaptors.OIDCAuthenticateOut, error) {
 	if in.Client != nil {
 		ctx = context.WithValue(ctx, oauth2.HTTPClient, in.Client)
 	}
@@ -31,9 +31,10 @@ func (*OIDC) Authenticate(ctx context.Context, in adaptors.OIDCAuthenticateIn) (
 			ClientSecret: in.ClientSecret,
 			Scopes:       append(in.ExtraScopes, oidc.ScopeOpenID),
 		},
-		LocalServerPort: in.LocalServerPort,
-		SkipOpenBrowser: in.SkipOpenBrowser,
-		AuthCodeOptions: []oauth2.AuthCodeOption{oauth2.AccessTypeOffline},
+		LocalServerPort:    in.LocalServerPort,
+		SkipOpenBrowser:    in.SkipOpenBrowser,
+		AuthCodeOptions:    []oauth2.AuthCodeOption{oauth2.AccessTypeOffline},
+		ShowLocalServerURL: cb.ShowLocalServerURL,
 	}
 	token, err := flow.GetToken(ctx)
 	if err != nil {

--- a/usecases/login.go
+++ b/usecases/login.go
@@ -74,15 +74,21 @@ func (u *Login) Do(ctx context.Context, in usecases.LoginIn) error {
 		return nil
 	}
 
-	out, err := u.OIDC.Authenticate(ctx, adaptors.OIDCAuthenticateIn{
-		Issuer:          authProvider.IDPIssuerURL(),
-		ClientID:        authProvider.ClientID(),
-		ClientSecret:    authProvider.ClientSecret(),
-		ExtraScopes:     authProvider.ExtraScopes(),
-		Client:          hc,
-		LocalServerPort: in.ListenPort,
-		SkipOpenBrowser: in.SkipOpenBrowser,
-	})
+	out, err := u.OIDC.Authenticate(ctx,
+		adaptors.OIDCAuthenticateIn{
+			Issuer:          authProvider.IDPIssuerURL(),
+			ClientID:        authProvider.ClientID(),
+			ClientSecret:    authProvider.ClientSecret(),
+			ExtraScopes:     authProvider.ExtraScopes(),
+			Client:          hc,
+			LocalServerPort: in.ListenPort,
+			SkipOpenBrowser: in.SkipOpenBrowser,
+		},
+		adaptors.OIDCAuthenticateCallback{
+			ShowLocalServerURL: func(url string) {
+				u.Logger.Logf("Open %s for authentication", url)
+			},
+		})
 	if err != nil {
 		return errors.Wrapf(err, "could not get token from OIDC provider")
 	}

--- a/usecases/login_test.go
+++ b/usecases/login_test.go
@@ -91,6 +91,9 @@ func TestLogin_Do(t *testing.T) {
 				ExtraScopes:     []string{},
 				LocalServerPort: 10000,
 				Client:          httpClient,
+			}, gomock.Any()).
+			Do(func(_ context.Context, _ adaptors.OIDCAuthenticateIn, cb adaptors.OIDCAuthenticateCallback) {
+				cb.ShowLocalServerURL("http://localhost:10000")
 			}).
 			Return(&adaptors.OIDCAuthenticateOut{
 				VerifiedIDToken: &oidc.IDToken{Subject: "SUBJECT"},
@@ -133,7 +136,7 @@ func TestLogin_Do(t *testing.T) {
 				ExtraScopes:     []string{},
 				LocalServerPort: 10000,
 				Client:          httpClient,
-			}).
+			}, gomock.Any()).
 			Return(&adaptors.OIDCAuthenticateOut{
 				VerifiedIDToken: &oidc.IDToken{Subject: "SUBJECT"},
 				IDToken:         "YOUR_ID_TOKEN",
@@ -177,7 +180,7 @@ func TestLogin_Do(t *testing.T) {
 				LocalServerPort: 10000,
 				Client:          httpClient,
 				SkipOpenBrowser: true,
-			}).
+			}, gomock.Any()).
 			Return(&adaptors.OIDCAuthenticateOut{
 				VerifiedIDToken: &oidc.IDToken{Subject: "SUBJECT"},
 				IDToken:         "YOUR_ID_TOKEN",
@@ -270,7 +273,7 @@ func TestLogin_Do(t *testing.T) {
 				ExtraScopes:     []string{},
 				LocalServerPort: 10000,
 				Client:          httpClient,
-			}).
+			}, gomock.Any()).
 			Return(&adaptors.OIDCAuthenticateOut{
 				VerifiedIDToken: &oidc.IDToken{Subject: "SUBJECT"},
 				IDToken:         "YOUR_ID_TOKEN",
@@ -313,7 +316,7 @@ func TestLogin_Do(t *testing.T) {
 				ExtraScopes:     []string{"email", "profile"},
 				LocalServerPort: 10000,
 				Client:          httpClient,
-			}).
+			}, gomock.Any()).
 			Return(&adaptors.OIDCAuthenticateOut{
 				VerifiedIDToken: &oidc.IDToken{Subject: "SUBJECT"},
 				IDToken:         "YOUR_ID_TOKEN",
@@ -358,7 +361,7 @@ func TestLogin_Do(t *testing.T) {
 				ExtraScopes:     []string{},
 				LocalServerPort: 10000,
 				Client:          httpClient,
-			}).
+			}, gomock.Any()).
 			Return(&adaptors.OIDCAuthenticateOut{
 				VerifiedIDToken: &oidc.IDToken{Subject: "SUBJECT"},
 				IDToken:         "YOUR_ID_TOKEN",
@@ -404,7 +407,7 @@ func TestLogin_Do(t *testing.T) {
 				ExtraScopes:     []string{},
 				LocalServerPort: 10000,
 				Client:          httpClient,
-			}).
+			}, gomock.Any()).
 			Return(&adaptors.OIDCAuthenticateOut{
 				VerifiedIDToken: &oidc.IDToken{Subject: "SUBJECT"},
 				IDToken:         "YOUR_ID_TOKEN",
@@ -449,7 +452,7 @@ func TestLogin_Do(t *testing.T) {
 				ExtraScopes:     []string{},
 				LocalServerPort: 10000,
 				Client:          httpClient,
-			}).
+			}, gomock.Any()).
 			Return(&adaptors.OIDCAuthenticateOut{
 				VerifiedIDToken: &oidc.IDToken{Subject: "SUBJECT"},
 				IDToken:         "YOUR_ID_TOKEN",
@@ -495,7 +498,7 @@ func TestLogin_Do(t *testing.T) {
 				ExtraScopes:     []string{},
 				LocalServerPort: 10000,
 				Client:          httpClient,
-			}).
+			}, gomock.Any()).
 			Return(&adaptors.OIDCAuthenticateOut{
 				VerifiedIDToken: &oidc.IDToken{Subject: "SUBJECT"},
 				IDToken:         "YOUR_ID_TOKEN",


### PR DESCRIPTION
This changes the authentication prompt from the default of oauth2cli to the Logger.