### PR TITLE
Add --context option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Kubelogin supports the following options.
 ```
 Options:
       --kubeconfig string          Path to the kubeconfig file (default "~/.kube/config")
+      --context string             The name of the kubeconfig context to use
       --listen-port int            Port used by kubelogin to bind its local server (default 8000)
       --skip-open-browser          If true, it does not open the browser on authentication
       --insecure-skip-tls-verify   If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure

--- a/adaptors/cmd.go
+++ b/adaptors/cmd.go
@@ -53,6 +53,7 @@ func (cmd *Cmd) Run(ctx context.Context, args []string, version string) int {
 	}
 	var o cmdOptions
 	f.StringVar(&o.KubeConfig, "kubeconfig", cmd.defaultKubeConfig(), "Path to the kubeconfig file")
+	f.StringVar(&o.KubeContext, "context", "", "The name of the kubeconfig context to use")
 	f.IntVar(&o.ListenPort, "listen-port", cmd.defaultListenPort(), "Port used by kubelogin to bind its local server")
 	f.BoolVar(&o.SkipOpenBrowser, "skip-open-browser", false, "If true, it does not open the browser on authentication")
 	f.BoolVar(&o.SkipTLSVerify, "insecure-skip-tls-verify", false, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure")
@@ -72,10 +73,11 @@ func (cmd *Cmd) Run(ctx context.Context, args []string, version string) int {
 
 	cmd.Logger.SetLevel(adaptors.LogLevel(o.Verbose))
 	in := usecases.LoginIn{
-		KubeConfig:      o.KubeConfig,
-		ListenPort:      o.ListenPort,
-		SkipTLSVerify:   o.SkipTLSVerify,
-		SkipOpenBrowser: o.SkipOpenBrowser,
+		KubeConfigFilename: o.KubeConfig,
+		KubeContextName:    o.KubeContext,
+		ListenPort:         o.ListenPort,
+		SkipTLSVerify:      o.SkipTLSVerify,
+		SkipOpenBrowser:    o.SkipOpenBrowser,
 	}
 	if err := cmd.Login.Do(ctx, in); err != nil {
 		cmd.Logger.Printf("Error: %s", err)
@@ -110,6 +112,7 @@ func (cmd *Cmd) defaultListenPort() int {
 
 type cmdOptions struct {
 	KubeConfig      string
+	KubeContext     string
 	SkipTLSVerify   bool
 	ListenPort      int
 	SkipOpenBrowser bool

--- a/adaptors/cmd_test.go
+++ b/adaptors/cmd_test.go
@@ -24,8 +24,8 @@ func TestCmd_Run(t *testing.T) {
 		login := mock_usecases.NewMockLogin(ctrl)
 		login.EXPECT().
 			Do(ctx, usecases.LoginIn{
-				KubeConfig: expand(t, "~/.kube/config"),
-				ListenPort: 8000,
+				KubeConfigFilename: expand(t, "~/.kube/config"),
+				ListenPort:         8000,
 			})
 
 		env := mock_adaptors.NewMockEnv(ctrl)
@@ -54,10 +54,11 @@ func TestCmd_Run(t *testing.T) {
 		login := mock_usecases.NewMockLogin(ctrl)
 		login.EXPECT().
 			Do(ctx, usecases.LoginIn{
-				KubeConfig:      "/path/to/kubeconfig",
-				ListenPort:      10080,
-				SkipTLSVerify:   true,
-				SkipOpenBrowser: true,
+				KubeConfigFilename: "/path/to/kubeconfig",
+				KubeContextName:    "hello.k8s.local",
+				ListenPort:         10080,
+				SkipTLSVerify:      true,
+				SkipOpenBrowser:    true,
 			})
 
 		env := mock_adaptors.NewMockEnv(ctrl)
@@ -74,6 +75,7 @@ func TestCmd_Run(t *testing.T) {
 		}
 		exitCode := cmd.Run(ctx, []string{executable,
 			"--kubeconfig", "/path/to/kubeconfig",
+			"--context", "hello.k8s.local",
 			"--listen-port", "10080",
 			"--insecure-skip-tls-verify",
 			"--skip-open-browser",
@@ -92,8 +94,8 @@ func TestCmd_Run(t *testing.T) {
 		login := mock_usecases.NewMockLogin(ctrl)
 		login.EXPECT().
 			Do(ctx, usecases.LoginIn{
-				KubeConfig: "/path/to/kubeconfig",
-				ListenPort: 10080,
+				KubeConfigFilename: "/path/to/kubeconfig",
+				ListenPort:         10080,
 			})
 
 		env := mock_adaptors.NewMockEnv(ctrl)

--- a/adaptors/interfaces/adaptors.go
+++ b/adaptors/interfaces/adaptors.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/coreos/go-oidc"
-	"k8s.io/client-go/tools/clientcmd/api"
+	"github.com/int128/kubelogin/kubeconfig"
 )
 
 //go:generate mockgen -package mock_adaptors -destination ../mock_adaptors/mock_adaptors.go github.com/int128/kubelogin/adaptors/interfaces KubeConfig,HTTP,HTTPClientConfig,OIDC,Env,Logger
@@ -16,8 +16,8 @@ type Cmd interface {
 }
 
 type KubeConfig interface {
-	LoadFromFile(filename string) (*api.Config, error)
-	WriteToFile(config *api.Config, filename string) error
+	LoadFromFile(filename string) (*kubeconfig.KubeConfig, error)
+	WriteToFile(config *kubeconfig.KubeConfig, filename string) error
 }
 
 type HTTP interface {

--- a/adaptors/kubeconfig.go
+++ b/adaptors/kubeconfig.go
@@ -2,6 +2,7 @@ package adaptors
 
 import (
 	"github.com/int128/kubelogin/adaptors/interfaces"
+	"github.com/int128/kubelogin/kubeconfig"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -13,16 +14,16 @@ func NewKubeConfig() adaptors.KubeConfig {
 
 type KubeConfig struct{}
 
-func (*KubeConfig) LoadFromFile(filename string) (*api.Config, error) {
+func (*KubeConfig) LoadFromFile(filename string) (*kubeconfig.KubeConfig, error) {
 	config, err := clientcmd.LoadFromFile(filename)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not read the kubeconfig from %s", filename)
 	}
-	return config, err
+	return (*kubeconfig.KubeConfig)(config), err
 }
 
-func (*KubeConfig) WriteToFile(config *api.Config, filename string) error {
-	err := clientcmd.WriteToFile(*config, filename)
+func (*KubeConfig) WriteToFile(config *kubeconfig.KubeConfig, filename string) error {
+	err := clientcmd.WriteToFile(*(*api.Config)(config), filename)
 	if err != nil {
 		return errors.Wrapf(err, "could not write the kubeconfig to %s", filename)
 	}

--- a/adaptors/mock_adaptors/mock_adaptors.go
+++ b/adaptors/mock_adaptors/mock_adaptors.go
@@ -10,7 +10,7 @@ import (
 	go_oidc "github.com/coreos/go-oidc"
 	gomock "github.com/golang/mock/gomock"
 	interfaces "github.com/int128/kubelogin/adaptors/interfaces"
-	api "k8s.io/client-go/tools/clientcmd/api"
+	kubeconfig "github.com/int128/kubelogin/kubeconfig"
 	http "net/http"
 	reflect "reflect"
 )
@@ -39,9 +39,9 @@ func (m *MockKubeConfig) EXPECT() *MockKubeConfigMockRecorder {
 }
 
 // LoadFromFile mocks base method
-func (m *MockKubeConfig) LoadFromFile(arg0 string) (*api.Config, error) {
+func (m *MockKubeConfig) LoadFromFile(arg0 string) (*kubeconfig.KubeConfig, error) {
 	ret := m.ctrl.Call(m, "LoadFromFile", arg0)
-	ret0, _ := ret[0].(*api.Config)
+	ret0, _ := ret[0].(*kubeconfig.KubeConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -52,7 +52,7 @@ func (mr *MockKubeConfigMockRecorder) LoadFromFile(arg0 interface{}) *gomock.Cal
 }
 
 // WriteToFile mocks base method
-func (m *MockKubeConfig) WriteToFile(arg0 *api.Config, arg1 string) error {
+func (m *MockKubeConfig) WriteToFile(arg0 *kubeconfig.KubeConfig, arg1 string) error {
 	ret := m.ctrl.Call(m, "WriteToFile", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/kubeconfig/auth.go
+++ b/kubeconfig/auth.go
@@ -3,32 +3,10 @@ package kubeconfig
 import (
 	"strings"
 
-	"github.com/pkg/errors"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
 
-// FindOIDCAuthProvider returns the current OIDC authProvider.
-// If the context, auth-info or auth-provider does not exist, this returns an error.
-// If auth-provider is not "oidc", this returns an error.
-func FindOIDCAuthProvider(config *api.Config) (*OIDCAuthProvider, error) {
-	context := config.Contexts[config.CurrentContext]
-	if context == nil {
-		return nil, errors.Errorf("context %s does not exist", config.CurrentContext)
-	}
-	authInfo := config.AuthInfos[context.AuthInfo]
-	if authInfo == nil {
-		return nil, errors.Errorf("auth-info %s does not exist", context.AuthInfo)
-	}
-	if authInfo.AuthProvider == nil {
-		return nil, errors.Errorf("auth-provider is not set")
-	}
-	if authInfo.AuthProvider.Name != "oidc" {
-		return nil, errors.Errorf("auth-provider name is %s but must be oidc", authInfo.AuthProvider.Name)
-	}
-	return (*OIDCAuthProvider)(authInfo.AuthProvider), nil
-}
-
-// OIDCAuthProvider represents OIDC configuration in the kubeconfig.
+// OIDCAuthProvider represents an OIDC auth-provider.
 type OIDCAuthProvider api.AuthProviderConfig
 
 // IDPIssuerURL returns the idp-issuer-url.

--- a/kubeconfig/kubeconfig.go
+++ b/kubeconfig/kubeconfig.go
@@ -1,0 +1,45 @@
+// Package kubeconfig provides the models of kuneconfig file.
+package kubeconfig
+
+import (
+	"github.com/pkg/errors"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+// KubeConfig represents a config.
+type KubeConfig api.Config
+
+// FindContext returns the context.
+// If the context does not exist, this returns an error.
+func (c *KubeConfig) FindContext(name string) (*KubeContext, error) {
+	contextNode := c.Contexts[name]
+	if contextNode == nil {
+		return nil, errors.Errorf("context %s does not exist", name)
+	}
+	return (*KubeContext)(contextNode), nil
+}
+
+// DeepCopy returns a deep copy.
+func (c *KubeConfig) DeepCopy() *KubeConfig {
+	return (*KubeConfig)((*api.Config)(c).DeepCopy())
+}
+
+// FindOIDCAuthProvider returns the OIDC auth-provider.
+//
+// If the auth-info or auth-provider does not exist, this returns an error.
+// If auth-provider is not "oidc", this returns an error.
+func (c *KubeConfig) FindOIDCAuthProvider(authInfoName string) (*OIDCAuthProvider, error) {
+	authInfoNode := c.AuthInfos[authInfoName]
+	if authInfoNode == nil {
+		return nil, errors.Errorf("user %s does not exist", authInfoName)
+	}
+	if authInfoNode.AuthProvider == nil {
+		return nil, errors.Errorf("auth-provider is not set")
+	}
+	if authInfoNode.AuthProvider.Name != "oidc" {
+		return nil, errors.Errorf("auth-provider must be oidc but was %s", authInfoNode.AuthProvider.Name)
+	}
+	return (*OIDCAuthProvider)(authInfoNode.AuthProvider), nil
+}
+
+type KubeContext api.Context

--- a/usecases/interfaces/usecases.go
+++ b/usecases/interfaces/usecases.go
@@ -9,8 +9,9 @@ type Login interface {
 }
 
 type LoginIn struct {
-	KubeConfig      string
-	SkipTLSVerify   bool
-	SkipOpenBrowser bool
-	ListenPort      int
+	KubeConfigFilename string
+	KubeContextName    string // default to the current context
+	SkipTLSVerify      bool
+	SkipOpenBrowser    bool
+	ListenPort         int
 }


### PR DESCRIPTION
This adds `--context` option for handling multiple clusters. See #63.