### PR TITLE
Dump all claims of ID token to debug log

### DIFF
--- a/adaptors_test/cmd_test.go
+++ b/adaptors_test/cmd_test.go
@@ -171,11 +171,19 @@ func TestCmd_Run(t *testing.T) {
 
 func newIDToken(t *testing.T, issuer string) string {
 	t.Helper()
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.StandardClaims{
+	var claims struct {
+		jwt.StandardClaims
+		Groups []string `json:"groups"`
+	}
+	claims.StandardClaims = jwt.StandardClaims{
 		Issuer:    issuer,
 		Audience:  "kubernetes",
 		ExpiresAt: time.Now().Add(time.Hour).Unix(),
-	})
+		Subject:   "SUBJECT",
+		IssuedAt:  time.Now().Unix(),
+	}
+	claims.Groups = []string{"admin", "users"}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 	s, err := token.SignedString(keys.JWSKeyPair)
 	if err != nil {
 		t.Fatalf("Could not sign the claims: %s", err)

--- a/usecases/login.go
+++ b/usecases/login.go
@@ -77,7 +77,8 @@ func (u *Login) Do(ctx context.Context, in usecases.LoginIn) error {
 		ClientID: authProvider.ClientID(),
 		Client:   hc,
 	}); token != nil {
-		u.Logger.Printf("You already have a valid token (until %s)", token.Expiry)
+		u.Logger.Printf("You already have a valid token until %s", token.Expiry)
+		u.dumpIDToken(token)
 		return nil
 	}
 
@@ -100,14 +101,8 @@ func (u *Login) Do(ctx context.Context, in usecases.LoginIn) error {
 		return errors.Wrapf(err, "could not get token from OIDC provider")
 	}
 
-	u.Logger.Printf("Got a token for subject %s (valid until %s)", out.VerifiedIDToken.Subject, out.VerifiedIDToken.Expiry)
-	var claims map[string]interface{}
-	if err := out.VerifiedIDToken.Claims(&claims); err != nil {
-		u.Logger.Debugf(1, "Skip inspection of the ID token: %s", err)
-	}
-	for k, v := range claims {
-		u.Logger.Debugf(1, "ID token has the claim: %s=%v", k, v)
-	}
+	u.Logger.Printf("You got a valid token until %s", out.VerifiedIDToken.Expiry)
+	u.dumpIDToken(out.VerifiedIDToken)
 	authProvider.SetIDToken(out.IDToken)
 	authProvider.SetRefreshToken(out.RefreshToken)
 
@@ -117,6 +112,16 @@ func (u *Login) Do(ctx context.Context, in usecases.LoginIn) error {
 	}
 	u.Logger.Printf("Updated %s", in.KubeConfigFilename)
 	return nil
+}
+
+func (u *Login) dumpIDToken(token *oidc.IDToken) {
+	var claims map[string]interface{}
+	if err := token.Claims(&claims); err != nil {
+		u.Logger.Debugf(1, "Error while inspection of the ID token: %s", err)
+	}
+	for k, v := range claims {
+		u.Logger.Debugf(1, "The ID token has the claim: %s=%v", k, v)
+	}
 }
 
 func (u *Login) findAuthProvider(kubeConfig *kubeconfig.KubeConfig, kubeContextName, kubeUserName string) (*kubeconfig.OIDCAuthProvider, error) {
@@ -150,6 +155,5 @@ func (u *Login) verifyIDToken(ctx context.Context, in adaptors.OIDCVerifyTokenIn
 		u.Logger.Debugf(1, "Could not verify the ID token in the kubeconfig: %s", err)
 		return nil
 	}
-	u.Logger.Debugf(1, "Verified token %+v", token)
 	return token
 }

--- a/usecases/login.go
+++ b/usecases/login.go
@@ -101,7 +101,13 @@ func (u *Login) Do(ctx context.Context, in usecases.LoginIn) error {
 	}
 
 	u.Logger.Printf("Got a token for subject %s (valid until %s)", out.VerifiedIDToken.Subject, out.VerifiedIDToken.Expiry)
-	u.Logger.Debugf(1, "Got an ID token %+v", out.VerifiedIDToken)
+	var claims map[string]interface{}
+	if err := out.VerifiedIDToken.Claims(&claims); err != nil {
+		u.Logger.Debugf(1, "Skip inspection of the ID token: %s", err)
+	}
+	for k, v := range claims {
+		u.Logger.Debugf(1, "ID token has the claim: %s=%v", k, v)
+	}
 	authProvider.SetIDToken(out.IDToken)
 	authProvider.SetRefreshToken(out.RefreshToken)
 


### PR DESCRIPTION
This adds dump of all claims of an ID token to debug log. See #64.