### PR TITLE
Fix error of go get and remove golint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,11 +11,13 @@ jobs:
           curl -L -o ~/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
           chmod +x ~/bin/kubectl
       - run: |
+          curl -L -o ~/bin/ghcp https://github.com/int128/ghcp/releases/download/v1.3.0/ghcp_linux_amd64
+          chmod +x ~/bin/ghcp
+      - run: |
           go get -v \
             golang.org/x/lint/golint \
             github.com/int128/goxzst \
-            github.com/tcnksm/ghr \
-            github.com/int128/ghcp
+            github.com/tcnksm/ghr
       - checkout
       # workaround for https://github.com/golang/go/issues/27925
       - run: sed -e '/^k8s.io\/client-go /d' -i go.sum

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,6 @@ jobs:
           chmod +x ~/bin/ghcp
       - run: |
           go get -v \
-            golang.org/x/lint/golint \
             github.com/int128/goxzst \
             github.com/tcnksm/ghr
       - checkout

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ LDFLAGS := -X main.version=$(CIRCLE_TAG)
 all: $(TARGET)
 
 check:
-	golint
 	go vet
 	$(MAKE) -C adaptors_test/keys/testdata
 	go test -v -race ./...


### PR DESCRIPTION
This will fix error of `go get github.com/int128/ghcp`. Also replace golint with golangci.