### PR TITLE
Bump to int128/oauth2cli:v1.4.0

### DIFF
--- a/adaptors/oidc.go
+++ b/adaptors/oidc.go
@@ -24,8 +24,8 @@ func (*OIDC) Authenticate(ctx context.Context, in adaptors.OIDCAuthenticateIn, c
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not discovery the OIDC issuer")
 	}
-	flow := oauth2cli.AuthCodeFlow{
-		Config: oauth2.Config{
+	config := oauth2cli.Config{
+		OAuth2Config: oauth2.Config{
 			Endpoint:     provider.Endpoint(),
 			ClientID:     in.Config.ClientID(),
 			ClientSecret: in.Config.ClientSecret(),
@@ -36,7 +36,7 @@ func (*OIDC) Authenticate(ctx context.Context, in adaptors.OIDCAuthenticateIn, c
 		AuthCodeOptions:    []oauth2.AuthCodeOption{oauth2.AccessTypeOffline},
 		ShowLocalServerURL: cb.ShowLocalServerURL,
 	}
-	token, err := flow.GetToken(ctx)
+	token, err := oauth2cli.GetToken(ctx, config)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get a token")
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang/mock v1.3.1
 	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
 	github.com/imdario/mergo v0.3.7 // indirect
-	github.com/int128/oauth2cli v1.3.0
+	github.com/int128/oauth2cli v1.4.0
 	github.com/json-iterator/go v1.1.6 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeq
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
-github.com/int128/oauth2cli v1.3.0 h1:0kVsHjnOyxcsUt+QpikJ/jiVCuyOkHDGpAyk78JGDMI=
-github.com/int128/oauth2cli v1.3.0/go.mod h1:R1iBtRu+y4+DF4efDU0UePUYWjWfggwFI1KY1dw5E1M=
+github.com/int128/oauth2cli v1.4.0 h1:Xt4uk2lIb9Mf9Xyd5o43Hf9iV5izb2jYK3zRX/cPgh0=
+github.com/int128/oauth2cli v1.4.0/go.mod h1:81pWOyFVt1TRyZ7lZDtZuAGOE/S/jEpb1mpocRopI6U=
 github.com/json-iterator/go v1.1.6 h1:MrUvLMLTMxbqFJ9kzlvat/rYZqZnW3u4wkLzWTaFwKs=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=


### PR DESCRIPTION
Bump to https://github.com/int128/oauth2cli/releases/tag/v1.4.0.