### PR TITLE
Refactor: use a dynamic port in the integration tests

### DIFF
--- a/adaptors/adaptors.go
+++ b/adaptors/adaptors.go
@@ -35,7 +35,7 @@ type OIDC interface {
 }
 
 type OIDCClient interface {
-	AuthenticateByCode(ctx context.Context, in OIDCAuthenticateByCodeIn, cb OIDCAuthenticateCallback) (*OIDCAuthenticateOut, error)
+	AuthenticateByCode(ctx context.Context, in OIDCAuthenticateByCodeIn) (*OIDCAuthenticateOut, error)
 	AuthenticateByPassword(ctx context.Context, in OIDCAuthenticateByPasswordIn) (*OIDCAuthenticateOut, error)
 	Verify(ctx context.Context, in OIDCVerifyIn) (*oidc.IDToken, error)
 }
@@ -44,16 +44,17 @@ type OIDCAuthenticateByCodeIn struct {
 	Config          kubeconfig.OIDCConfig
 	LocalServerPort []int // HTTP server port candidates
 	SkipOpenBrowser bool  // skip opening browser if true
+	Prompt          OIDCAuthenticateByCodePrompt
+}
+
+type OIDCAuthenticateByCodePrompt interface {
+	ShowLocalServerURL(url string)
 }
 
 type OIDCAuthenticateByPasswordIn struct {
 	Config   kubeconfig.OIDCConfig
 	Username string
 	Password string
-}
-
-type OIDCAuthenticateCallback struct {
-	ShowLocalServerURL func(url string)
 }
 
 type OIDCAuthenticateOut struct {

--- a/adaptors/mock_adaptors/mock_adaptors.go
+++ b/adaptors/mock_adaptors/mock_adaptors.go
@@ -171,16 +171,16 @@ func (m *MockOIDCClient) EXPECT() *MockOIDCClientMockRecorder {
 }
 
 // AuthenticateByCode mocks base method
-func (m *MockOIDCClient) AuthenticateByCode(arg0 context.Context, arg1 adaptors.OIDCAuthenticateByCodeIn, arg2 adaptors.OIDCAuthenticateCallback) (*adaptors.OIDCAuthenticateOut, error) {
-	ret := m.ctrl.Call(m, "AuthenticateByCode", arg0, arg1, arg2)
+func (m *MockOIDCClient) AuthenticateByCode(arg0 context.Context, arg1 adaptors.OIDCAuthenticateByCodeIn) (*adaptors.OIDCAuthenticateOut, error) {
+	ret := m.ctrl.Call(m, "AuthenticateByCode", arg0, arg1)
 	ret0, _ := ret[0].(*adaptors.OIDCAuthenticateOut)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AuthenticateByCode indicates an expected call of AuthenticateByCode
-func (mr *MockOIDCClientMockRecorder) AuthenticateByCode(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthenticateByCode", reflect.TypeOf((*MockOIDCClient)(nil).AuthenticateByCode), arg0, arg1, arg2)
+func (mr *MockOIDCClientMockRecorder) AuthenticateByCode(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthenticateByCode", reflect.TypeOf((*MockOIDCClient)(nil).AuthenticateByCode), arg0, arg1)
 }
 
 // AuthenticateByPassword mocks base method

--- a/adaptors/oidc/oidc.go
+++ b/adaptors/oidc/oidc.go
@@ -31,7 +31,7 @@ type Client struct {
 	hc *http.Client
 }
 
-func (c *Client) AuthenticateByCode(ctx context.Context, in adaptors.OIDCAuthenticateByCodeIn, cb adaptors.OIDCAuthenticateCallback) (*adaptors.OIDCAuthenticateOut, error) {
+func (c *Client) AuthenticateByCode(ctx context.Context, in adaptors.OIDCAuthenticateByCodeIn) (*adaptors.OIDCAuthenticateOut, error) {
 	if c.hc != nil {
 		ctx = context.WithValue(ctx, oauth2.HTTPClient, c.hc)
 	}
@@ -49,7 +49,7 @@ func (c *Client) AuthenticateByCode(ctx context.Context, in adaptors.OIDCAuthent
 		LocalServerPort:    in.LocalServerPort,
 		SkipOpenBrowser:    in.SkipOpenBrowser,
 		AuthCodeOptions:    []oauth2.AuthCodeOption{oauth2.AccessTypeOffline},
-		ShowLocalServerURL: cb.ShowLocalServerURL,
+		ShowLocalServerURL: in.Prompt.ShowLocalServerURL,
 	}
 	token, err := oauth2cli.GetToken(ctx, config)
 	if err != nil {

--- a/adaptors_test/authserver/authserver.go
+++ b/adaptors_test/authserver/authserver.go
@@ -5,34 +5,73 @@
 package authserver
 
 import (
+	"context"
+	"net"
 	"net/http"
 	"testing"
 )
 
-// Config represents an authentication server configuration.
-type Config struct {
-	Addr          string
-	TLSServerCert string
-	TLSServerKey  string
-	Handler       http.Handler
+type Shutdowner interface {
+	Shutdown(t *testing.T, ctx context.Context)
+}
+
+type shutdowner struct {
+	l net.Listener
+	s *http.Server
+}
+
+func (s *shutdowner) Shutdown(t *testing.T, ctx context.Context) {
+	// s.Shutdown() closes the lister as well,
+	// so we do not need to call l.Close() explicitly
+	if err := s.s.Shutdown(ctx); err != nil {
+		t.Errorf("Could not shutdown the server: %s", err)
+	}
 }
 
 // Start starts an authentication server.
-func Start(t *testing.T, c Config) *http.Server {
+func Start(t *testing.T, h func(url string) http.Handler) Shutdowner {
+	t.Helper()
+	l, port := newLocalhostListener(t)
+	url := "http://localhost:" + port
 	s := &http.Server{
-		Addr:    c.Addr,
-		Handler: c.Handler,
+		Handler: h(url),
 	}
 	go func() {
-		var err error
-		if c.TLSServerCert != "" && c.TLSServerKey != "" {
-			err = s.ListenAndServeTLS(c.TLSServerCert, c.TLSServerKey)
-		} else {
-			err = s.ListenAndServe()
-		}
+		err := s.Serve(l)
 		if err != nil && err != http.ErrServerClosed {
 			t.Error(err)
 		}
 	}()
-	return s
+	return &shutdowner{l, s}
+}
+
+// Start starts an authentication server with TLS.
+func StartTLS(t *testing.T, cert string, key string, h func(url string) http.Handler) Shutdowner {
+	t.Helper()
+	l, port := newLocalhostListener(t)
+	url := "https://localhost:" + port
+	s := &http.Server{
+		Handler: h(url),
+	}
+	go func() {
+		err := s.ServeTLS(l, cert, key)
+		if err != nil && err != http.ErrServerClosed {
+			t.Error(err)
+		}
+	}()
+	return &shutdowner{l, s}
+}
+
+func newLocalhostListener(t *testing.T) (net.Listener, string) {
+	t.Helper()
+	l, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("Could not create a listener: %s", err)
+	}
+	addr := l.Addr().String()
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("Could not parse the address %s: %s", addr, err)
+	}
+	return l, port
 }

--- a/adaptors_test/cmd_test.go
+++ b/adaptors_test/cmd_test.go
@@ -34,18 +34,17 @@ func TestCmd_Run(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 
-		codeConfig := authserver.CodeConfig{
-			Issuer:         "http://localhost:9001",
-			IDToken:        newIDToken(t, "http://localhost:9001"),
-			IDTokenKeyPair: keys.JWSKeyPair,
-			RefreshToken:   "REFRESH_TOKEN",
-		}
-		serverConfig := authserver.Config{
-			Addr:    "localhost:9001",
-			Handler: authserver.NewCodeHandler(t, codeConfig),
-		}
-		server := authserver.Start(t, serverConfig)
-		defer shutdown(t, ctx, server)
+		var codeConfig authserver.CodeConfig
+		server := authserver.Start(t, func(url string) http.Handler {
+			codeConfig = authserver.CodeConfig{
+				Issuer:         url,
+				IDToken:        newIDToken(t, url),
+				IDTokenKeyPair: keys.JWSKeyPair,
+				RefreshToken:   "REFRESH_TOKEN",
+			}
+			return authserver.NewCodeHandler(t, codeConfig)
+		})
+		defer server.Shutdown(t, ctx)
 
 		kubeConfigFilename := kubeconfig.Create(t, &kubeconfig.Values{
 			Issuer: codeConfig.Issuer,
@@ -67,20 +66,19 @@ func TestCmd_Run(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 
-		passwordConfig := authserver.PasswordConfig{
-			Issuer:         "http://localhost:9007",
-			IDToken:        newIDToken(t, "http://localhost:9007"),
-			IDTokenKeyPair: keys.JWSKeyPair,
-			RefreshToken:   "REFRESH_TOKEN",
-			Username:       "USER",
-			Password:       "PASS",
-		}
-		serverConfig := authserver.Config{
-			Addr:    "localhost:9007",
-			Handler: authserver.NewPasswordHandler(t, passwordConfig),
-		}
-		server := authserver.Start(t, serverConfig)
-		defer shutdown(t, ctx, server)
+		var passwordConfig authserver.PasswordConfig
+		server := authserver.Start(t, func(url string) http.Handler {
+			passwordConfig = authserver.PasswordConfig{
+				Issuer:         url,
+				IDToken:        newIDToken(t, url),
+				IDTokenKeyPair: keys.JWSKeyPair,
+				RefreshToken:   "REFRESH_TOKEN",
+				Username:       "USER",
+				Password:       "PASS",
+			}
+			return authserver.NewPasswordHandler(t, passwordConfig)
+		})
+		defer server.Shutdown(t, ctx)
 
 		kubeConfigFilename := kubeconfig.Create(t, &kubeconfig.Values{
 			Issuer: passwordConfig.Issuer,
@@ -99,18 +97,17 @@ func TestCmd_Run(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 
-		codeConfig := authserver.CodeConfig{
-			Issuer:         "http://localhost:9002",
-			IDToken:        newIDToken(t, "http://localhost:9002"),
-			IDTokenKeyPair: keys.JWSKeyPair,
-			RefreshToken:   "REFRESH_TOKEN",
-		}
-		serverConfig := authserver.Config{
-			Addr:    "localhost:9002",
-			Handler: authserver.NewCodeHandler(t, codeConfig),
-		}
-		server := authserver.Start(t, serverConfig)
-		defer shutdown(t, ctx, server)
+		var codeConfig authserver.CodeConfig
+		server := authserver.Start(t, func(url string) http.Handler {
+			codeConfig = authserver.CodeConfig{
+				Issuer:         url,
+				IDToken:        newIDToken(t, url),
+				IDTokenKeyPair: keys.JWSKeyPair,
+				RefreshToken:   "REFRESH_TOKEN",
+			}
+			return authserver.NewCodeHandler(t, codeConfig)
+		})
+		defer server.Shutdown(t, ctx)
 
 		kubeConfigFilename := kubeconfig.Create(t, &kubeconfig.Values{
 			Issuer: codeConfig.Issuer,
@@ -135,19 +132,18 @@ func TestCmd_Run(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 
-		codeConfig := authserver.CodeConfig{
-			Issuer:         "http://localhost:9003",
-			IDToken:        newIDToken(t, "http://localhost:9003"),
-			IDTokenKeyPair: keys.JWSKeyPair,
-			RefreshToken:   "REFRESH_TOKEN",
-			Scope:          "profile groups openid",
-		}
-		serverConfig := authserver.Config{
-			Addr:    "localhost:9003",
-			Handler: authserver.NewCodeHandler(t, codeConfig),
-		}
-		server := authserver.Start(t, serverConfig)
-		defer shutdown(t, ctx, server)
+		var codeConfig authserver.CodeConfig
+		server := authserver.Start(t, func(url string) http.Handler {
+			codeConfig = authserver.CodeConfig{
+				Issuer:         url,
+				IDToken:        newIDToken(t, url),
+				IDTokenKeyPair: keys.JWSKeyPair,
+				RefreshToken:   "REFRESH_TOKEN",
+				Scope:          "profile groups openid",
+			}
+			return authserver.NewCodeHandler(t, codeConfig)
+		})
+		defer server.Shutdown(t, ctx)
 
 		kubeConfigFilename := kubeconfig.Create(t, &kubeconfig.Values{
 			Issuer:      codeConfig.Issuer,
@@ -170,20 +166,17 @@ func TestCmd_Run(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 
-		codeConfig := authserver.CodeConfig{
-			Issuer:         "https://localhost:9004",
-			IDToken:        newIDToken(t, "https://localhost:9004"),
-			IDTokenKeyPair: keys.JWSKeyPair,
-			RefreshToken:   "REFRESH_TOKEN",
-		}
-		serverConfig := authserver.Config{
-			Addr:          "localhost:9004",
-			Handler:       authserver.NewCodeHandler(t, codeConfig),
-			TLSServerCert: keys.TLSServerCert,
-			TLSServerKey:  keys.TLSServerKey,
-		}
-		server := authserver.Start(t, serverConfig)
-		defer shutdown(t, ctx, server)
+		var codeConfig authserver.CodeConfig
+		server := authserver.StartTLS(t, keys.TLSServerCert, keys.TLSServerKey, func(url string) http.Handler {
+			codeConfig = authserver.CodeConfig{
+				Issuer:         url,
+				IDToken:        newIDToken(t, url),
+				IDTokenKeyPair: keys.JWSKeyPair,
+				RefreshToken:   "REFRESH_TOKEN",
+			}
+			return authserver.NewCodeHandler(t, codeConfig)
+		})
+		defer server.Shutdown(t, ctx)
 
 		kubeConfigFilename := kubeconfig.Create(t, &kubeconfig.Values{
 			Issuer:                  codeConfig.Issuer,
@@ -206,20 +199,17 @@ func TestCmd_Run(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 
-		codeConfig := authserver.CodeConfig{
-			Issuer:         "https://localhost:9005",
-			IDToken:        newIDToken(t, "https://localhost:9005"),
-			IDTokenKeyPair: keys.JWSKeyPair,
-			RefreshToken:   "REFRESH_TOKEN",
-		}
-		serverConfig := authserver.Config{
-			Addr:          "localhost:9005",
-			Handler:       authserver.NewCodeHandler(t, codeConfig),
-			TLSServerCert: keys.TLSServerCert,
-			TLSServerKey:  keys.TLSServerKey,
-		}
-		server := authserver.Start(t, serverConfig)
-		defer shutdown(t, ctx, server)
+		var codeConfig authserver.CodeConfig
+		server := authserver.StartTLS(t, keys.TLSServerCert, keys.TLSServerKey, func(url string) http.Handler {
+			codeConfig = authserver.CodeConfig{
+				Issuer:         url,
+				IDToken:        newIDToken(t, url),
+				IDTokenKeyPair: keys.JWSKeyPair,
+				RefreshToken:   "REFRESH_TOKEN",
+			}
+			return authserver.NewCodeHandler(t, codeConfig)
+		})
+		defer server.Shutdown(t, ctx)
 
 		kubeConfigFilename := kubeconfig.Create(t, &kubeconfig.Values{
 			Issuer:                      codeConfig.Issuer,
@@ -242,16 +232,15 @@ func TestCmd_Run(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 
-		codeConfig := authserver.CodeConfig{
-			Issuer:         "http://localhost:9006",
-			IDTokenKeyPair: keys.JWSKeyPair,
-		}
-		serverConfig := authserver.Config{
-			Addr:    "localhost:9006",
-			Handler: authserver.NewCodeHandler(t, codeConfig),
-		}
-		server := authserver.Start(t, serverConfig)
-		defer shutdown(t, ctx, server)
+		var codeConfig authserver.CodeConfig
+		server := authserver.Start(t, func(url string) http.Handler {
+			codeConfig = authserver.CodeConfig{
+				Issuer:         url,
+				IDTokenKeyPair: keys.JWSKeyPair,
+			}
+			return authserver.NewCodeHandler(t, codeConfig)
+		})
+		defer server.Shutdown(t, ctx)
 
 		idToken := newIDToken(t, codeConfig.Issuer)
 		kubeConfigFilename := kubeconfig.Create(t, &kubeconfig.Values{
@@ -321,12 +310,6 @@ func startBrowserRequest(t *testing.T, ctx context.Context, wg *sync.WaitGroup, 
 		}
 	}()
 	wg.Add(1)
-}
-
-func shutdown(t *testing.T, ctx context.Context, s *http.Server) {
-	if err := s.Shutdown(ctx); err != nil {
-		t.Errorf("Could not shutdown the auth server: %s", err)
-	}
 }
 
 func setenv(t *testing.T, key, value string) {

--- a/adaptors_test/cmd_test.go
+++ b/adaptors_test/cmd_test.go
@@ -15,16 +15,15 @@ import (
 	"github.com/int128/kubelogin/adaptors_test/kubeconfig"
 	"github.com/int128/kubelogin/adaptors_test/logger"
 	"github.com/int128/kubelogin/di"
+	"github.com/int128/kubelogin/usecases"
 )
 
 // Run the integration tests.
-// This assumes that port 800x and 900x are available.
 //
-// 1. Start the auth server at port 900x.
+// 1. Start the auth server.
 // 2. Run the Cmd.
-// 3. Open a request for port 800x.
-// 4. Wait for the Cmd.
-// 5. Shutdown the auth server.
+// 3. Open a request for the local server.
+// 4. Verify the kuneconfig.
 //
 func TestCmd_Run(t *testing.T) {
 	timeout := 1 * time.Second
@@ -51,10 +50,9 @@ func TestCmd_Run(t *testing.T) {
 		})
 		defer os.Remove(kubeConfigFilename)
 
-		var wg sync.WaitGroup
-		startBrowserRequest(t, ctx, &wg, "http://localhost:8001", nil)
-		runCmd(t, ctx, "--kubeconfig", kubeConfigFilename, "--skip-open-browser", "--listen-port", "8001")
-		wg.Wait()
+		req := startBrowserRequest(t, ctx, nil)
+		runCmd(t, ctx, req, "--kubeconfig", kubeConfigFilename, "--skip-open-browser", "--listen-port", "0")
+		req.wait()
 		kubeconfig.Verify(t, kubeConfigFilename, kubeconfig.AuthProviderConfig{
 			IDToken:      codeConfig.IDToken,
 			RefreshToken: "REFRESH_TOKEN",
@@ -85,7 +83,7 @@ func TestCmd_Run(t *testing.T) {
 		})
 		defer os.Remove(kubeConfigFilename)
 
-		runCmd(t, ctx, "--kubeconfig", kubeConfigFilename, "--skip-open-browser", "--username", "USER", "--password", "PASS")
+		runCmd(t, ctx, nil, "--kubeconfig", kubeConfigFilename, "--skip-open-browser", "--username", "USER", "--password", "PASS")
 		kubeconfig.Verify(t, kubeConfigFilename, kubeconfig.AuthProviderConfig{
 			IDToken:      passwordConfig.IDToken,
 			RefreshToken: "REFRESH_TOKEN",
@@ -117,10 +115,9 @@ func TestCmd_Run(t *testing.T) {
 		setenv(t, "KUBECONFIG", kubeConfigFilename+string(os.PathListSeparator)+"kubeconfig/testdata/dummy.yaml")
 		defer unsetenv(t, "KUBECONFIG")
 
-		var wg sync.WaitGroup
-		startBrowserRequest(t, ctx, &wg, "http://localhost:8002", nil)
-		runCmd(t, ctx, "--skip-open-browser", "--listen-port", "8002")
-		wg.Wait()
+		req := startBrowserRequest(t, ctx, nil)
+		runCmd(t, ctx, req, "--skip-open-browser", "--listen-port", "0")
+		req.wait()
 		kubeconfig.Verify(t, kubeConfigFilename, kubeconfig.AuthProviderConfig{
 			IDToken:      codeConfig.IDToken,
 			RefreshToken: "REFRESH_TOKEN",
@@ -151,10 +148,9 @@ func TestCmd_Run(t *testing.T) {
 		})
 		defer os.Remove(kubeConfigFilename)
 
-		var wg sync.WaitGroup
-		startBrowserRequest(t, ctx, &wg, "http://localhost:8003", nil)
-		runCmd(t, ctx, "--kubeconfig", kubeConfigFilename, "--skip-open-browser", "--listen-port", "8003")
-		wg.Wait()
+		req := startBrowserRequest(t, ctx, nil)
+		runCmd(t, ctx, req, "--kubeconfig", kubeConfigFilename, "--skip-open-browser", "--listen-port", "0")
+		req.wait()
 		kubeconfig.Verify(t, kubeConfigFilename, kubeconfig.AuthProviderConfig{
 			IDToken:      codeConfig.IDToken,
 			RefreshToken: "REFRESH_TOKEN",
@@ -184,10 +180,9 @@ func TestCmd_Run(t *testing.T) {
 		})
 		defer os.Remove(kubeConfigFilename)
 
-		var wg sync.WaitGroup
-		startBrowserRequest(t, ctx, &wg, "http://localhost:8004", keys.TLSCACertAsConfig)
-		runCmd(t, ctx, "--kubeconfig", kubeConfigFilename, "--skip-open-browser", "--listen-port", "8004")
-		wg.Wait()
+		req := startBrowserRequest(t, ctx, keys.TLSCACertAsConfig)
+		runCmd(t, ctx, req, "--kubeconfig", kubeConfigFilename, "--skip-open-browser", "--listen-port", "0")
+		req.wait()
 		kubeconfig.Verify(t, kubeConfigFilename, kubeconfig.AuthProviderConfig{
 			IDToken:      codeConfig.IDToken,
 			RefreshToken: "REFRESH_TOKEN",
@@ -217,10 +212,9 @@ func TestCmd_Run(t *testing.T) {
 		})
 		defer os.Remove(kubeConfigFilename)
 
-		var wg sync.WaitGroup
-		startBrowserRequest(t, ctx, &wg, "http://localhost:8005", keys.TLSCACertAsConfig)
-		runCmd(t, ctx, "--kubeconfig", kubeConfigFilename, "--skip-open-browser", "--listen-port", "8005")
-		wg.Wait()
+		req := startBrowserRequest(t, ctx, keys.TLSCACertAsConfig)
+		runCmd(t, ctx, req, "--kubeconfig", kubeConfigFilename, "--skip-open-browser", "--listen-port", "0")
+		req.wait()
 		kubeconfig.Verify(t, kubeConfigFilename, kubeconfig.AuthProviderConfig{
 			IDToken:      codeConfig.IDToken,
 			RefreshToken: "REFRESH_TOKEN",
@@ -249,7 +243,7 @@ func TestCmd_Run(t *testing.T) {
 		})
 		defer os.Remove(kubeConfigFilename)
 
-		runCmd(t, ctx, "--kubeconfig", kubeConfigFilename, "--skip-open-browser")
+		runCmd(t, ctx, nil, "--kubeconfig", kubeConfigFilename, "--skip-open-browser")
 		kubeconfig.Verify(t, kubeConfigFilename, kubeconfig.AuthProviderConfig{
 			IDToken: idToken,
 		})
@@ -278,38 +272,61 @@ func newIDToken(t *testing.T, issuer string) string {
 	return s
 }
 
-func runCmd(t *testing.T, ctx context.Context, args ...string) {
+func runCmd(t *testing.T, ctx context.Context, p usecases.LoginPrompt, args ...string) {
 	t.Helper()
-	cmd := di.NewCmd(logger.New(t))
+	cmd := di.NewCmdWith(logger.New(t), p)
 	exitCode := cmd.Run(ctx, append([]string{"kubelogin", "--v=1"}, args...), "HEAD")
 	if exitCode != 0 {
 		t.Errorf("exit status wants 0 but %d", exitCode)
 	}
 }
 
-func startBrowserRequest(t *testing.T, ctx context.Context, wg *sync.WaitGroup, url string, tlsConfig *tls.Config) {
+type browserRequest struct {
+	t     *testing.T
+	urlCh chan<- string
+	wg    *sync.WaitGroup
+}
+
+func (r *browserRequest) ShowLocalServerURL(url string) {
+	defer close(r.urlCh)
+	r.t.Logf("Open %s for authentication", url)
+	r.urlCh <- url
+}
+
+func (r *browserRequest) wait() {
+	r.wg.Wait()
+}
+
+func startBrowserRequest(t *testing.T, ctx context.Context, tlsConfig *tls.Config) *browserRequest {
 	t.Helper()
-	client := http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		t.Errorf("could not create a request: %s", err)
-		return
-	}
-	req = req.WithContext(ctx)
+	urlCh := make(chan string)
+	var wg sync.WaitGroup
 	go func() {
 		defer wg.Done()
-		time.Sleep(50 * time.Millisecond)
-		resp, err := client.Do(req)
-		if err != nil {
-			t.Errorf("could not send a request: %s", err)
-			return
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode != 200 {
-			t.Errorf("StatusCode wants 200 but %d", resp.StatusCode)
+		select {
+		case url := <-urlCh:
+			client := http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}
+			req, err := http.NewRequest("GET", url, nil)
+			if err != nil {
+				t.Errorf("could not create a request: %s", err)
+				return
+			}
+			req = req.WithContext(ctx)
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Errorf("could not send a request: %s", err)
+				return
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != 200 {
+				t.Errorf("StatusCode wants 200 but %d", resp.StatusCode)
+			}
+		case err := <-ctx.Done():
+			t.Errorf("context done while waiting for URL prompt: %s", err)
 		}
 	}()
 	wg.Add(1)
+	return &browserRequest{t, urlCh, &wg}
 }
 
 func setenv(t *testing.T, key, value string) {

--- a/di/di.go
+++ b/di/di.go
@@ -9,6 +9,7 @@ import (
 	"github.com/int128/kubelogin/adaptors/cmd"
 	"github.com/int128/kubelogin/adaptors/http"
 	"github.com/int128/kubelogin/adaptors/kubeconfig"
+	"github.com/int128/kubelogin/adaptors/logger"
 	"github.com/int128/kubelogin/adaptors/oidc"
 	"github.com/int128/kubelogin/usecases"
 	"github.com/int128/kubelogin/usecases/login"
@@ -30,7 +31,22 @@ var adaptorsSet = wire.NewSet(
 	wire.Bind((*adaptors.OIDC)(nil), (*oidc.OIDC)(nil)),
 )
 
-func NewCmd(logger adaptors.Logger) adaptors.Cmd {
+var extraSet = wire.NewSet(
+	login.Prompt{},
+	wire.Bind((*usecases.LoginPrompt)(nil), (*login.Prompt)(nil)),
+	logger.New,
+)
+
+func NewCmd() adaptors.Cmd {
+	wire.Build(
+		usecasesSet,
+		adaptorsSet,
+		extraSet,
+	)
+	return nil
+}
+
+func NewCmdWith(adaptors.Logger, usecases.LoginPrompt) adaptors.Cmd {
 	wire.Build(
 		usecasesSet,
 		adaptorsSet,

--- a/main.go
+++ b/main.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"os"
 
-	"github.com/int128/kubelogin/adaptors/logger"
 	"github.com/int128/kubelogin/di"
 )
 
 var version = "HEAD"
 
 func main() {
-	os.Exit(di.NewCmd(logger.New()).Run(context.Background(), os.Args, version))
+	os.Exit(di.NewCmd().Run(context.Background(), os.Args, version))
 }

--- a/usecases/login/login_test.go
+++ b/usecases/login/login_test.go
@@ -169,7 +169,15 @@ func newLoginTestFixture() loginTestFixture {
 	return f
 }
 
+type mockPrompt struct{}
+
+func (*mockPrompt) ShowLocalServerURL(url string) {
+	panic("do not call")
+}
+
 func TestLogin_Do(t *testing.T) {
+	var prompt mockPrompt
+
 	newMockOIDC := func(ctrl *gomock.Controller, config adaptors.HTTPClientConfig, client adaptors.OIDCClient) *mock_adaptors.MockOIDC {
 		mockOIDC := mock_adaptors.NewMockOIDC(ctrl)
 		mockOIDC.EXPECT().
@@ -181,10 +189,7 @@ func TestLogin_Do(t *testing.T) {
 	newMockCodeOIDC := func(ctrl *gomock.Controller, ctx context.Context, in adaptors.OIDCAuthenticateByCodeIn) *mock_adaptors.MockOIDCClient {
 		mockOIDCClient := mock_adaptors.NewMockOIDCClient(ctrl)
 		mockOIDCClient.EXPECT().
-			AuthenticateByCode(ctx, in, gomock.Any()).
-			Do(func(_ context.Context, _ adaptors.OIDCAuthenticateByCodeIn, cb adaptors.OIDCAuthenticateCallback) {
-				cb.ShowLocalServerURL("http://localhost:10000")
-			}).
+			AuthenticateByCode(ctx, in).
 			Return(&adaptors.OIDCAuthenticateOut{
 				VerifiedIDToken: &oidc.IDToken{Subject: "SUBJECT"},
 				IDToken:         "YOUR_ID_TOKEN",
@@ -214,12 +219,14 @@ func TestLogin_Do(t *testing.T) {
 		}, newMockCodeOIDC(ctrl, ctx, adaptors.OIDCAuthenticateByCodeIn{
 			Config:          f.googleOIDCConfig,
 			LocalServerPort: []int{10000},
+			Prompt:          &prompt,
 		}))
 
 		u := Login{
 			KubeConfig: mockKubeConfig,
 			OIDC:       mockOIDC,
 			Logger:     mock_adaptors.NewLogger(t, ctrl),
+			Prompt:     &prompt,
 		}
 		if err := u.Do(ctx, usecases.LoginIn{
 			ListenPort: []int{10000},
@@ -296,12 +303,14 @@ func TestLogin_Do(t *testing.T) {
 		}, newMockCodeOIDC(ctrl, ctx, adaptors.OIDCAuthenticateByCodeIn{
 			Config:          f.googleOIDCConfig,
 			LocalServerPort: []int{10000},
+			Prompt:          &prompt,
 		}))
 
 		u := Login{
 			KubeConfig: mockKubeConfig,
 			OIDC:       mockOIDC,
 			Logger:     mock_adaptors.NewLogger(t, ctrl),
+			Prompt:     &prompt,
 		}
 		if err := u.Do(ctx, usecases.LoginIn{
 			KubeConfigFilename: "/path/to/kubeconfig",
@@ -332,12 +341,14 @@ func TestLogin_Do(t *testing.T) {
 		}, newMockCodeOIDC(ctrl, ctx, adaptors.OIDCAuthenticateByCodeIn{
 			Config:          f.keycloakOIDCConfig,
 			LocalServerPort: []int{10000},
+			Prompt:          &prompt,
 		}))
 
 		u := Login{
 			KubeConfig: mockKubeConfig,
 			OIDC:       mockOIDC,
 			Logger:     mock_adaptors.NewLogger(t, ctrl),
+			Prompt:     &prompt,
 		}
 		if err := u.Do(ctx, usecases.LoginIn{
 			KubeContextName: "keycloakContext",
@@ -368,12 +379,14 @@ func TestLogin_Do(t *testing.T) {
 		}, newMockCodeOIDC(ctrl, ctx, adaptors.OIDCAuthenticateByCodeIn{
 			Config:          f.keycloakOIDCConfig,
 			LocalServerPort: []int{10000},
+			Prompt:          &prompt,
 		}))
 
 		u := Login{
 			KubeConfig: mockKubeConfig,
 			OIDC:       mockOIDC,
 			Logger:     mock_adaptors.NewLogger(t, ctrl),
+			Prompt:     &prompt,
 		}
 		if err := u.Do(ctx, usecases.LoginIn{
 			KubeUserName: "keycloak",
@@ -405,12 +418,14 @@ func TestLogin_Do(t *testing.T) {
 		}, newMockCodeOIDC(ctrl, ctx, adaptors.OIDCAuthenticateByCodeIn{
 			Config:          f.googleOIDCConfig,
 			LocalServerPort: []int{10000},
+			Prompt:          &prompt,
 		}))
 
 		u := Login{
 			KubeConfig: mockKubeConfig,
 			OIDC:       mockOIDC,
 			Logger:     mock_adaptors.NewLogger(t, ctrl),
+			Prompt:     &prompt,
 		}
 		if err := u.Do(ctx, usecases.LoginIn{
 			ListenPort:    []int{10000},
@@ -442,12 +457,14 @@ func TestLogin_Do(t *testing.T) {
 			Config:          f.googleOIDCConfig,
 			LocalServerPort: []int{10000},
 			SkipOpenBrowser: true,
+			Prompt:          &prompt,
 		}))
 
 		u := Login{
 			KubeConfig: mockKubeConfig,
 			OIDC:       mockOIDC,
 			Logger:     mock_adaptors.NewLogger(t, ctrl),
+			Prompt:     &prompt,
 		}
 		if err := u.Do(ctx, usecases.LoginIn{
 			ListenPort:      []int{10000},
@@ -514,6 +531,7 @@ func TestLogin_Do(t *testing.T) {
 		mockOIDCClient := newMockCodeOIDC(ctrl, ctx, adaptors.OIDCAuthenticateByCodeIn{
 			Config:          f.googleOIDCConfig,
 			LocalServerPort: []int{10000},
+			Prompt:          &prompt,
 		})
 		mockOIDCClient.EXPECT().
 			Verify(ctx, adaptors.OIDCVerifyIn{
@@ -528,6 +546,7 @@ func TestLogin_Do(t *testing.T) {
 			KubeConfig: mockKubeConfig,
 			OIDC:       mockOIDC,
 			Logger:     mock_adaptors.NewLogger(t, ctrl),
+			Prompt:     &prompt,
 		}
 		if err := u.Do(ctx, usecases.LoginIn{
 			ListenPort: []int{10000},
@@ -562,12 +581,14 @@ func TestLogin_Do(t *testing.T) {
 		}, newMockCodeOIDC(ctrl, ctx, adaptors.OIDCAuthenticateByCodeIn{
 			Config:          f.googleOIDCConfig,
 			LocalServerPort: []int{10000},
+			Prompt:          &prompt,
 		}))
 
 		u := Login{
 			KubeConfig: mockKubeConfig,
 			OIDC:       mockOIDC,
 			Logger:     mock_adaptors.NewLogger(t, ctrl),
+			Prompt:     &prompt,
 		}
 		if err := u.Do(ctx, usecases.LoginIn{
 			ListenPort:                   []int{10000},

--- a/usecases/usecases.go
+++ b/usecases/usecases.go
@@ -23,3 +23,7 @@ type LoginIn struct {
 	CertificateAuthorityFilename string // Optional
 	SkipTLSVerify                bool
 }
+
+type LoginPrompt interface {
+	ShowLocalServerURL(url string)
+}


### PR DESCRIPTION
This is refactoring of the integration tests. Currently it uses fixed ports (800x and 900x) but they may conflict in some environment. This improving test stability by using dynamic allocated ports.

This includes the design changes:
- Externalize the prompt as `usecases.LoginPrompt` interface and `adaptors.OIDCAuthenticateByCodePrompt`.
- In the integration tests, inject the special prompt to send a browser request.