### PR TITLE
Fix build error of windows_amd64 binary

### DIFF
--- a/adaptors/env/env.go
+++ b/adaptors/env/env.go
@@ -19,7 +19,7 @@ func (*Env) ReadPassword(prompt string) (string, error) {
 	if _, err := fmt.Fprint(os.Stderr, "Password: "); err != nil {
 		return "", errors.Wrapf(err, "could not write the prompt")
 	}
-	b, err := terminal.ReadPassword(syscall.Stdin)
+	b, err := terminal.ReadPassword(int(syscall.Stdin))
 	if err != nil {
 		return "", errors.Wrapf(err, "could not read")
 	}

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,7 @@ github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/int128/oauth2cli v1.4.0 h1:Xt4uk2lIb9Mf9Xyd5o43Hf9iV5izb2jYK3zRX/cPgh0=
 github.com/int128/oauth2cli v1.4.0/go.mod h1:81pWOyFVt1TRyZ7lZDtZuAGOE/S/jEpb1mpocRopI6U=


### PR DESCRIPTION
This will fix #96.

```
% make dist
VERSION=HEAD goxzst -d dist/gh/ -o "kubelogin" -t "kubelogin.rb oidc-login.yaml" -- -ldflags "-X main.version=HEAD"
2019/06/06 08:34:33 GOOS=linux GOARCH=amd64 go build -o dist/gh/kubelogin_linux_amd64 -ldflags -X main.version=HEAD
2019/06/06 08:35:04 Creating dist/gh/kubelogin_linux_amd64.zip
2019/06/06 08:35:05 Creating dist/gh/kubelogin_linux_amd64.zip.sha256
2019/06/06 08:35:05 GOOS=darwin GOARCH=amd64 go build -o dist/gh/kubelogin_darwin_amd64 -ldflags -X main.version=HEAD
2019/06/06 08:35:09 Creating dist/gh/kubelogin_darwin_amd64.zip
2019/06/06 08:35:11 Creating dist/gh/kubelogin_darwin_amd64.zip.sha256
2019/06/06 08:35:11 GOOS=windows GOARCH=amd64 go build -o dist/gh/kubelogin_windows_amd64.exe -ldflags -X main.version=HEAD
2019/06/06 08:35:43 Creating dist/gh/kubelogin_windows_amd64.zip
2019/06/06 08:35:45 Creating dist/gh/kubelogin_windows_amd64.zip.sha256
2019/06/06 08:35:45 Creating dist/gh/kubelogin.rb from the template kubelogin.rb
2019/06/06 08:35:45 Creating dist/gh/oidc-login.yaml from the template oidc-login.yaml
2019/06/06 08:35:45 Removing dist/gh/kubelogin_linux_amd64
2019/06/06 08:35:45 Removing dist/gh/kubelogin_darwin_amd64
2019/06/06 08:35:45 Removing dist/gh/kubelogin_windows_amd64.exe
mv dist/gh/kubelogin.rb dist/
```