### PR TITLE
Cache oidc.Provider to reduce discovery requests

### DIFF
--- a/adaptors/interfaces.go
+++ b/adaptors/interfaces.go
@@ -19,7 +19,7 @@ type Kubeconfig interface {
 }
 
 type OIDC interface {
-	New(config OIDCClientConfig) (OIDCClient, error)
+	New(ctx context.Context, config OIDCClientConfig) (OIDCClient, error)
 }
 
 type OIDCClientConfig struct {
@@ -35,14 +35,12 @@ type OIDCClient interface {
 }
 
 type OIDCAuthenticateByCodeIn struct {
-	Config             kubeconfig.OIDCConfig
 	LocalServerPort    []int // HTTP server port candidates
 	SkipOpenBrowser    bool  // skip opening browser if true
 	ShowLocalServerURL interface{ ShowLocalServerURL(url string) }
 }
 
 type OIDCAuthenticateByPasswordIn struct {
-	Config   kubeconfig.OIDCConfig
 	Username string
 	Password string
 }
@@ -54,7 +52,7 @@ type OIDCAuthenticateOut struct {
 }
 
 type OIDCVerifyIn struct {
-	Config kubeconfig.OIDCConfig
+	IDToken string
 }
 
 type Env interface {

--- a/adaptors/mock_adaptors/mock_adaptors.go
+++ b/adaptors/mock_adaptors/mock_adaptors.go
@@ -85,16 +85,16 @@ func (m *MockOIDC) EXPECT() *MockOIDCMockRecorder {
 }
 
 // New mocks base method
-func (m *MockOIDC) New(arg0 adaptors.OIDCClientConfig) (adaptors.OIDCClient, error) {
-	ret := m.ctrl.Call(m, "New", arg0)
+func (m *MockOIDC) New(arg0 context.Context, arg1 adaptors.OIDCClientConfig) (adaptors.OIDCClient, error) {
+	ret := m.ctrl.Call(m, "New", arg0, arg1)
 	ret0, _ := ret[0].(adaptors.OIDCClient)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // New indicates an expected call of New
-func (mr *MockOIDCMockRecorder) New(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "New", reflect.TypeOf((*MockOIDC)(nil).New), arg0)
+func (mr *MockOIDCMockRecorder) New(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "New", reflect.TypeOf((*MockOIDC)(nil).New), arg0, arg1)
 }
 
 // MockOIDCClient is a mock of OIDCClient interface

--- a/usecases/login/exec_test.go
+++ b/usecases/login/exec_test.go
@@ -28,9 +28,8 @@ func TestExec_Do(t *testing.T) {
 
 		mockOIDC := mock_adaptors.NewMockOIDC(ctrl)
 		mockOIDC.EXPECT().
-			New(adaptors.OIDCClientConfig{Config: auth.OIDCConfig}).
+			New(ctx, adaptors.OIDCClientConfig{Config: auth.OIDCConfig}).
 			Return(newMockCodeOIDC(ctrl, ctx, adaptors.OIDCAuthenticateByCodeIn{
-				Config:          auth.OIDCConfig,
 				LocalServerPort: []int{10000},
 			}), nil)
 

--- a/usecases/login/login.go
+++ b/usecases/login/login.go
@@ -56,7 +56,7 @@ func (u *Login) Do(ctx context.Context, in usecases.LoginIn) error {
 	u.Logger.Debugf(1, "Using the authentication provider of the user %s", auth.UserName)
 	u.Logger.Debugf(1, "A token will be written to %s", auth.LocationOfOrigin)
 
-	client, err := u.OIDC.New(adaptors.OIDCClientConfig{
+	client, err := u.OIDC.New(ctx, adaptors.OIDCClientConfig{
 		Config:         auth.OIDCConfig,
 		CACertFilename: in.CACertFilename,
 		SkipTLSVerify:  in.SkipTLSVerify,
@@ -67,7 +67,7 @@ func (u *Login) Do(ctx context.Context, in usecases.LoginIn) error {
 
 	if auth.OIDCConfig.IDToken != "" {
 		u.Logger.Debugf(1, "Found the ID token in the kubeconfig")
-		token, err := client.Verify(ctx, adaptors.OIDCVerifyIn{Config: auth.OIDCConfig})
+		token, err := client.Verify(ctx, adaptors.OIDCVerifyIn{IDToken: auth.OIDCConfig.IDToken})
 		if err == nil {
 			u.Logger.Printf("You already have a valid token until %s", token.Expiry)
 			dumpIDToken(u.Logger, token)
@@ -85,7 +85,6 @@ func (u *Login) Do(ctx context.Context, in usecases.LoginIn) error {
 			}
 		}
 		out, err := client.AuthenticateByPassword(ctx, adaptors.OIDCAuthenticateByPasswordIn{
-			Config:   auth.OIDCConfig,
 			Username: in.Username,
 			Password: in.Password,
 		})
@@ -95,7 +94,6 @@ func (u *Login) Do(ctx context.Context, in usecases.LoginIn) error {
 		tokenSet = out
 	} else {
 		out, err := client.AuthenticateByCode(ctx, adaptors.OIDCAuthenticateByCodeIn{
-			Config:             auth.OIDCConfig,
 			LocalServerPort:    in.ListenPort,
 			SkipOpenBrowser:    in.SkipOpenBrowser,
 			ShowLocalServerURL: u.ShowLocalServerURL,

--- a/usecases/login/login_test.go
+++ b/usecases/login/login_test.go
@@ -68,9 +68,8 @@ func TestLogin_Do(t *testing.T) {
 
 		mockOIDC := mock_adaptors.NewMockOIDC(ctrl)
 		mockOIDC.EXPECT().
-			New(adaptors.OIDCClientConfig{Config: auth.OIDCConfig}).
+			New(ctx, adaptors.OIDCClientConfig{Config: auth.OIDCConfig}).
 			Return(newMockCodeOIDC(ctrl, ctx, adaptors.OIDCAuthenticateByCodeIn{
-				Config:          auth.OIDCConfig,
 				LocalServerPort: []int{10000},
 			}), nil)
 
@@ -101,13 +100,12 @@ func TestLogin_Do(t *testing.T) {
 
 		mockOIDC := mock_adaptors.NewMockOIDC(ctrl)
 		mockOIDC.EXPECT().
-			New(adaptors.OIDCClientConfig{
+			New(ctx, adaptors.OIDCClientConfig{
 				Config:         auth.OIDCConfig,
 				CACertFilename: "/path/to/cert",
 				SkipTLSVerify:  true,
 			}).
 			Return(newMockPasswordOIDC(ctrl, ctx, adaptors.OIDCAuthenticateByPasswordIn{
-				Config:   auth.OIDCConfig,
 				Username: "USER",
 				Password: "PASS",
 			}), nil)
@@ -145,9 +143,8 @@ func TestLogin_Do(t *testing.T) {
 
 		mockOIDC := mock_adaptors.NewMockOIDC(ctrl)
 		mockOIDC.EXPECT().
-			New(adaptors.OIDCClientConfig{Config: auth.OIDCConfig}).
+			New(ctx, adaptors.OIDCClientConfig{Config: auth.OIDCConfig}).
 			Return(newMockPasswordOIDC(ctrl, ctx, adaptors.OIDCAuthenticateByPasswordIn{
-				Config:   auth.OIDCConfig,
 				Username: "USER",
 				Password: "PASS",
 			}), nil)
@@ -181,7 +178,7 @@ func TestLogin_Do(t *testing.T) {
 
 		mockOIDC := mock_adaptors.NewMockOIDC(ctrl)
 		mockOIDC.EXPECT().
-			New(adaptors.OIDCClientConfig{Config: auth.OIDCConfig}).
+			New(ctx, adaptors.OIDCClientConfig{Config: auth.OIDCConfig}).
 			Return(mock_adaptors.NewMockOIDCClient(ctrl), nil)
 
 		mockEnv := mock_adaptors.NewMockEnv(ctrl)
@@ -213,11 +210,11 @@ func TestLogin_Do(t *testing.T) {
 
 		mockOIDCClient := mock_adaptors.NewMockOIDCClient(ctrl)
 		mockOIDCClient.EXPECT().
-			Verify(ctx, adaptors.OIDCVerifyIn{Config: auth.OIDCConfig}).
+			Verify(ctx, adaptors.OIDCVerifyIn{IDToken: auth.OIDCConfig.IDToken}).
 			Return(&oidc.IDToken{Expiry: time.Now()}, nil)
 		mockOIDC := mock_adaptors.NewMockOIDC(ctrl)
 		mockOIDC.EXPECT().
-			New(adaptors.OIDCClientConfig{Config: auth.OIDCConfig}).
+			New(ctx, adaptors.OIDCClientConfig{Config: auth.OIDCConfig}).
 			Return(mockOIDCClient, nil)
 
 		u := Login{
@@ -243,13 +240,13 @@ func TestLogin_Do(t *testing.T) {
 		mockKubeconfig.EXPECT().
 			UpdateAuth(newAuth("YOUR_ID_TOKEN", "YOUR_REFRESH_TOKEN"))
 
-		mockOIDCClient := newMockCodeOIDC(ctrl, ctx, adaptors.OIDCAuthenticateByCodeIn{Config: auth.OIDCConfig})
+		mockOIDCClient := newMockCodeOIDC(ctrl, ctx, adaptors.OIDCAuthenticateByCodeIn{})
 		mockOIDCClient.EXPECT().
-			Verify(ctx, adaptors.OIDCVerifyIn{Config: auth.OIDCConfig}).
+			Verify(ctx, adaptors.OIDCVerifyIn{IDToken: auth.OIDCConfig.IDToken}).
 			Return(nil, xerrors.New("token expired"))
 		mockOIDC := mock_adaptors.NewMockOIDC(ctrl)
 		mockOIDC.EXPECT().
-			New(adaptors.OIDCClientConfig{Config: auth.OIDCConfig}).
+			New(ctx, adaptors.OIDCClientConfig{Config: auth.OIDCConfig}).
 			Return(mockOIDCClient, nil)
 
 		u := Login{


### PR DESCRIPTION
This will reduce requests to discovery the OIDC provider when the token has expired.

Current implementation sends the following requests:

```
10:00:40.443654 Found the ID token in the kubeconfig
10:00:40.444144 GET /auth/realms/hello/.well-known/openid-configuration HTTP/1.1
10:00:41.742795 The ID token was invalid: could not verify the id_token: oidc: token is expired (Token Expiry: 2019-06-26 10:00:33 +0900 JST)
10:00:41.743226 GET /auth/realms/hello/.well-known/openid-configuration HTTP/1.1
10:00:43.272939 POST /auth/realms/hello/protocol/openid-connect/token HTTP/1.1
10:00:43.538417 GET /auth/realms/hello/protocol/openid-connect/certs HTTP/1.1
```

This will change to:

```
09:55:31.082259 GET /auth/realms/hello/.well-known/openid-configuration HTTP/1.1
09:55:32.569343 Found the ID token in the kubeconfig
09:55:32.569960 The ID token was invalid: could not verify the id_token: oidc: token is expired (Token Expiry: 2019-06-25 22:38:00 +0900 JST)
09:55:36.775102 POST /auth/realms/hello/protocol/openid-connect/token HTTP/1.1
09:55:36.993754 GET /auth/realms/hello/protocol/openid-connect/certs HTTP/1.1
```
