### PR TITLE
Show caller filename and line on debug log

### DIFF
--- a/adaptors/logger/logger.go
+++ b/adaptors/logger/logger.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"fmt"
 	"log"
 	"os"
 
@@ -17,32 +18,32 @@ var Set = wire.NewSet(
 func New() adaptors.Logger {
 	return &Logger{
 		stdLogger:   log.New(os.Stderr, "", 0),
-		debugLogger: log.New(os.Stderr, "", log.Ltime|log.Lmicroseconds),
+		debugLogger: log.New(os.Stderr, "", log.Ltime|log.Lmicroseconds|log.Lshortfile),
 	}
 }
 
-// FromStdLogger returns a Logger with the given standard log.Logger.
-func FromStdLogger(l stdLogger) *Logger {
-	return &Logger{
-		stdLogger:   l,
-		debugLogger: l,
-	}
+func NewWith(s stdLogger, d debugLogger) *Logger {
+	return &Logger{s, d, 0}
 }
 
 type stdLogger interface {
 	Printf(format string, v ...interface{})
 }
 
+type debugLogger interface {
+	Output(calldepth int, s string) error
+}
+
 // Logger wraps the standard log.Logger and just provides debug level.
 type Logger struct {
 	stdLogger
-	debugLogger stdLogger
-	level       adaptors.LogLevel
+	debugLogger
+	level adaptors.LogLevel
 }
 
 func (l *Logger) Debugf(level adaptors.LogLevel, format string, v ...interface{}) {
 	if l.IsEnabled(level) {
-		l.debugLogger.Printf(format, v...)
+		_ = l.debugLogger.Output(2, fmt.Sprintf(format, v...))
 	}
 }
 

--- a/adaptors/logger/logger_test.go
+++ b/adaptors/logger/logger_test.go
@@ -7,12 +7,13 @@ import (
 	"github.com/int128/kubelogin/adaptors"
 )
 
-type mockStdLogger struct {
+type mockDebugLogger struct {
 	count int
 }
 
-func (l *mockStdLogger) Printf(format string, v ...interface{}) {
+func (l *mockDebugLogger) Output(int, string) error {
 	l.count++
+	return nil
 }
 
 func TestLogger_Debugf(t *testing.T) {
@@ -33,7 +34,7 @@ func TestLogger_Debugf(t *testing.T) {
 		{2, 3, 0},
 	} {
 		t.Run(fmt.Sprintf("%+v", c), func(t *testing.T) {
-			m := &mockStdLogger{}
+			m := &mockDebugLogger{}
 			l := &Logger{debugLogger: m, level: c.loggerLevel}
 			l.Debugf(c.debugfLevel, "hello")
 			if m.count != c.count {
@@ -41,6 +42,14 @@ func TestLogger_Debugf(t *testing.T) {
 			}
 		})
 	}
+}
+
+type mockStdLogger struct {
+	count int
+}
+
+func (l *mockStdLogger) Printf(format string, v ...interface{}) {
+	l.count++
 }
 
 func TestLogger_Printf(t *testing.T) {

--- a/e2e_test/logger/logger.go
+++ b/e2e_test/logger/logger.go
@@ -5,7 +5,8 @@ import (
 )
 
 func New(t testingLogger) *logger.Logger {
-	return logger.FromStdLogger(&bridge{t})
+	b := &bridge{t}
+	return logger.NewWith(b, b)
 }
 
 type testingLogger interface {
@@ -18,4 +19,9 @@ type bridge struct {
 
 func (b *bridge) Printf(format string, v ...interface{}) {
 	b.t.Logf(format, v...)
+}
+
+func (b *bridge) Output(calldepth int, s string) error {
+	b.t.Logf("%s", s)
+	return nil
 }


### PR DESCRIPTION
This adds a filename and line of caller in the debug log. This is useful for debug.

```
10:24:33.049932 login.go:40: WARNING: log may contain your secrets such as token or password
10:24:33.054602 login.go:47: Using the authentication provider of the user keycloak
10:24:33.054638 login.go:48: A token will be written to .kubeconfig
10:24:36.438311 auth.go:58: Verifying the token in the kubeconfig
10:24:36.747499 auth.go:73: You have an expired token at 2019-07-05 10:15:02 +0900 JST
10:24:36.747538 auth.go:77: Refreshing the token
10:24:37.799233 login.go:63: ID token has the claim: jti=xxxxxxxx
```