### PR TITLE
Check nonce of ID token on authentication

### DIFF
--- a/e2e_test/idp/mock_idp/mock_service.go
+++ b/e2e_test/idp/mock_idp/mock_service.go
@@ -34,16 +34,16 @@ func (m *MockService) EXPECT() *MockServiceMockRecorder {
 }
 
 // AuthenticateCode mocks base method
-func (m *MockService) AuthenticateCode(arg0 string) (string, error) {
-	ret := m.ctrl.Call(m, "AuthenticateCode", arg0)
+func (m *MockService) AuthenticateCode(arg0, arg1 string) (string, error) {
+	ret := m.ctrl.Call(m, "AuthenticateCode", arg0, arg1)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AuthenticateCode indicates an expected call of AuthenticateCode
-func (mr *MockServiceMockRecorder) AuthenticateCode(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthenticateCode", reflect.TypeOf((*MockService)(nil).AuthenticateCode), arg0)
+func (mr *MockServiceMockRecorder) AuthenticateCode(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthenticateCode", reflect.TypeOf((*MockService)(nil).AuthenticateCode), arg0, arg1)
 }
 
 // AuthenticatePassword mocks base method

--- a/e2e_test/idp/service.go
+++ b/e2e_test/idp/service.go
@@ -16,7 +16,7 @@ import (
 type Service interface {
 	Discovery() *DiscoveryResponse
 	GetCertificates() *CertificatesResponse
-	AuthenticateCode(scope string) (code string, err error)
+	AuthenticateCode(scope, nonce string) (code string, err error)
 	Exchange(code string) (*TokenResponse, error)
 	AuthenticatePassword(username, password, scope string) (*TokenResponse, error)
 	Refresh(refreshToken string) (*TokenResponse, error)


### PR DESCRIPTION
This adds checking the nonce of the ID token in the authorization code flow. It prevents the replay attack and improves security.

This has tested with Keycloak.