### PR TITLE
Save token cache for each issuer and client ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ If the cached ID token is valid, kubelogin just returns it.
 If the cached ID token has expired, kubelogin will refresh the token using the refresh token.
 If the refresh token has expired, kubelogin will perform reauthentication.
 
-You can log out by removing the token cache file (default `~/.kube/oidc-login.token-cache`).
+You can log out by removing the token cache directory (default `~/.kube/cache/oidc-login`).
 Kubelogin will perform authentication if the token cache file does not exist.
 
 
@@ -195,7 +195,7 @@ Flags:
       --certificate-authority string   Path to a cert file for the certificate authority
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
   -v, --v int                          If set to 1 or greater, it shows debug log
-      --token-cache string             Path to a file for caching the token (default "~/.kube/oidc-login.token-cache")
+      --token-cache-dir string         Path to a directory for caching tokens (default "~/.kube/cache/oidc-login")
   -h, --help                           help for get-token
 ```
 

--- a/e2e_test/credetial_plugin_test.go
+++ b/e2e_test/credetial_plugin_test.go
@@ -2,6 +2,8 @@ package e2e_test
 
 import (
 	"context"
+	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -26,6 +28,15 @@ import (
 //
 func TestCmd_Run_CredentialPlugin(t *testing.T) {
 	timeout := 1 * time.Second
+	cacheDir, err := ioutil.TempDir("", "kube")
+	if err != nil {
+		t.Fatalf("could not create a cache dir: %s", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(cacheDir); err != nil {
+			t.Errorf("could not clean up the cache dir: %s", err)
+		}
+	}()
 
 	t.Run("Defaults", func(t *testing.T) {
 		t.Parallel()
@@ -56,7 +67,7 @@ func TestCmd_Run_CredentialPlugin(t *testing.T) {
 		runGetTokenCmd(t, ctx, req, credentialPluginInteraction,
 			"--skip-open-browser",
 			"--listen-port", "0",
-			"--token-cache", "/dev/null",
+			"--token-cache-dir", cacheDir,
 			"--oidc-issuer-url", serverURL,
 			"--oidc-client-id", "kubernetes",
 		)

--- a/pkg/adaptors/cmd/cmd.go
+++ b/pkg/adaptors/cmd/cmd.go
@@ -31,7 +31,7 @@ const examples = `  # Login to the provider using the authorization code flow.
   %[1]s get-token --oidc-issuer-url=https://issuer.example.com`
 
 var defaultListenPort = []int{8000, 18000}
-var defaultTokenCache = homedir.HomeDir() + "/.kube/oidc-login.token-cache"
+var defaultTokenCacheDir = homedir.HomeDir() + "/.kube/cache/oidc-login"
 
 // Cmd provides interaction with command line interface (CLI).
 type Cmd struct {
@@ -152,7 +152,7 @@ type getTokenOptions struct {
 	CertificateAuthority string
 	SkipTLSVerify        bool
 	Verbose              int
-	TokenCacheFilename   string
+	TokenCacheDir        string
 }
 
 func (o *getTokenOptions) register(f *pflag.FlagSet) {
@@ -165,7 +165,7 @@ func (o *getTokenOptions) register(f *pflag.FlagSet) {
 	f.StringVar(&o.CertificateAuthority, "certificate-authority", "", "Path to a cert file for the certificate authority")
 	f.BoolVar(&o.SkipTLSVerify, "insecure-skip-tls-verify", false, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure")
 	f.IntVarP(&o.Verbose, "v", "v", 0, "If set to 1 or greater, it shows debug log")
-	f.StringVar(&o.TokenCacheFilename, "token-cache", defaultTokenCache, "Path to a file for caching the token")
+	f.StringVar(&o.TokenCacheDir, "token-cache-dir", defaultTokenCacheDir, "Path to a directory for caching tokens")
 }
 
 func newGetTokenCmd(ctx context.Context, cmd *Cmd) *cobra.Command {
@@ -188,17 +188,17 @@ func newGetTokenCmd(ctx context.Context, cmd *Cmd) *cobra.Command {
 		RunE: func(*cobra.Command, []string) error {
 			cmd.Logger.SetLevel(adaptors.LogLevel(o.Verbose))
 			in := usecases.GetTokenIn{
-				IssuerURL:          o.IssuerURL,
-				ClientID:           o.ClientID,
-				ClientSecret:       o.ClientSecret,
-				ExtraScopes:        o.ExtraScopes,
-				CACertFilename:     o.CertificateAuthority,
-				SkipTLSVerify:      o.SkipTLSVerify,
-				ListenPort:         o.ListenPort,
-				SkipOpenBrowser:    o.SkipOpenBrowser,
-				Username:           o.Username,
-				Password:           o.Password,
-				TokenCacheFilename: o.TokenCacheFilename,
+				IssuerURL:       o.IssuerURL,
+				ClientID:        o.ClientID,
+				ClientSecret:    o.ClientSecret,
+				ExtraScopes:     o.ExtraScopes,
+				CACertFilename:  o.CertificateAuthority,
+				SkipTLSVerify:   o.SkipTLSVerify,
+				ListenPort:      o.ListenPort,
+				SkipOpenBrowser: o.SkipOpenBrowser,
+				Username:        o.Username,
+				Password:        o.Password,
+				TokenCacheDir:   o.TokenCacheDir,
 			}
 			if err := cmd.GetToken.Do(ctx, in); err != nil {
 				return xerrors.Errorf("error: %w", err)

--- a/pkg/adaptors/cmd/cmd_test.go
+++ b/pkg/adaptors/cmd/cmd_test.go
@@ -104,10 +104,10 @@ func TestCmd_Run(t *testing.T) {
 		getToken := mock_usecases.NewMockGetToken(ctrl)
 		getToken.EXPECT().
 			Do(ctx, usecases.GetTokenIn{
-				ListenPort:         defaultListenPort,
-				TokenCacheFilename: defaultTokenCache,
-				IssuerURL:          "https://issuer.example.com",
-				ClientID:           "YOUR_CLIENT_ID",
+				ListenPort:    defaultListenPort,
+				TokenCacheDir: defaultTokenCacheDir,
+				IssuerURL:     "https://issuer.example.com",
+				ClientID:      "YOUR_CLIENT_ID",
 			})
 
 		logger := mock_adaptors.NewLogger(t, ctrl)
@@ -135,17 +135,17 @@ func TestCmd_Run(t *testing.T) {
 		getToken := mock_usecases.NewMockGetToken(ctrl)
 		getToken.EXPECT().
 			Do(ctx, usecases.GetTokenIn{
-				TokenCacheFilename: defaultTokenCache,
-				IssuerURL:          "https://issuer.example.com",
-				ClientID:           "YOUR_CLIENT_ID",
-				ClientSecret:       "YOUR_CLIENT_SECRET",
-				ExtraScopes:        []string{"email", "profile"},
-				CACertFilename:     "/path/to/cacert",
-				SkipTLSVerify:      true,
-				ListenPort:         []int{10080, 20080},
-				SkipOpenBrowser:    true,
-				Username:           "USER",
-				Password:           "PASS",
+				TokenCacheDir:   defaultTokenCacheDir,
+				IssuerURL:       "https://issuer.example.com",
+				ClientID:        "YOUR_CLIENT_ID",
+				ClientSecret:    "YOUR_CLIENT_SECRET",
+				ExtraScopes:     []string{"email", "profile"},
+				CACertFilename:  "/path/to/cacert",
+				SkipTLSVerify:   true,
+				ListenPort:      []int{10080, 20080},
+				SkipOpenBrowser: true,
+				Username:        "USER",
+				Password:        "PASS",
 			})
 
 		logger := mock_adaptors.NewLogger(t, ctrl)

--- a/pkg/adaptors/interfaces.go
+++ b/pkg/adaptors/interfaces.go
@@ -20,8 +20,8 @@ type Kubeconfig interface {
 }
 
 type TokenCacheRepository interface {
-	Read(filename string) (*credentialplugin.TokenCache, error)
-	Write(filename string, tc credentialplugin.TokenCache) error
+	FindByKey(dir string, key credentialplugin.TokenCacheKey) (*credentialplugin.TokenCache, error)
+	Save(dir string, key credentialplugin.TokenCacheKey, cache credentialplugin.TokenCache) error
 }
 
 type CredentialPluginInteraction interface {

--- a/pkg/adaptors/mock_adaptors/mock_adaptors.go
+++ b/pkg/adaptors/mock_adaptors/mock_adaptors.go
@@ -84,29 +84,29 @@ func (m *MockTokenCacheRepository) EXPECT() *MockTokenCacheRepositoryMockRecorde
 	return m.recorder
 }
 
-// Read mocks base method
-func (m *MockTokenCacheRepository) Read(arg0 string) (*credentialplugin.TokenCache, error) {
-	ret := m.ctrl.Call(m, "Read", arg0)
+// FindByKey mocks base method
+func (m *MockTokenCacheRepository) FindByKey(arg0 string, arg1 credentialplugin.TokenCacheKey) (*credentialplugin.TokenCache, error) {
+	ret := m.ctrl.Call(m, "FindByKey", arg0, arg1)
 	ret0, _ := ret[0].(*credentialplugin.TokenCache)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Read indicates an expected call of Read
-func (mr *MockTokenCacheRepositoryMockRecorder) Read(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockTokenCacheRepository)(nil).Read), arg0)
+// FindByKey indicates an expected call of FindByKey
+func (mr *MockTokenCacheRepositoryMockRecorder) FindByKey(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByKey", reflect.TypeOf((*MockTokenCacheRepository)(nil).FindByKey), arg0, arg1)
 }
 
-// Write mocks base method
-func (m *MockTokenCacheRepository) Write(arg0 string, arg1 credentialplugin.TokenCache) error {
-	ret := m.ctrl.Call(m, "Write", arg0, arg1)
+// Save mocks base method
+func (m *MockTokenCacheRepository) Save(arg0 string, arg1 credentialplugin.TokenCacheKey, arg2 credentialplugin.TokenCache) error {
+	ret := m.ctrl.Call(m, "Save", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Write indicates an expected call of Write
-func (mr *MockTokenCacheRepositoryMockRecorder) Write(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockTokenCacheRepository)(nil).Write), arg0, arg1)
+// Save indicates an expected call of Save
+func (mr *MockTokenCacheRepositoryMockRecorder) Save(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Save", reflect.TypeOf((*MockTokenCacheRepository)(nil).Save), arg0, arg1, arg2)
 }
 
 // MockCredentialPluginInteraction is a mock of CredentialPluginInteraction interface

--- a/pkg/adaptors/tokencache/tokencache.go
+++ b/pkg/adaptors/tokencache/tokencache.go
@@ -1,8 +1,11 @@
 package tokencache
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"os"
+	"path/filepath"
 
 	"github.com/google/wire"
 	"github.com/int128/kubelogin/pkg/adaptors"
@@ -16,9 +19,12 @@ var Set = wire.NewSet(
 	wire.Bind(new(adaptors.TokenCacheRepository), new(*Repository)),
 )
 
+// Repository provides access to the token cache on the local filesystem.
+// Filename of a token cache is sha256 digest of the issuer, zero-character and client ID.
 type Repository struct{}
 
-func (*Repository) Read(filename string) (*credentialplugin.TokenCache, error) {
+func (r *Repository) FindByKey(dir string, key credentialplugin.TokenCacheKey) (*credentialplugin.TokenCache, error) {
+	filename := filepath.Join(dir, computeFilename(key))
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, xerrors.Errorf("could not open file %s: %w", filename, err)
@@ -32,15 +38,27 @@ func (*Repository) Read(filename string) (*credentialplugin.TokenCache, error) {
 	return &c, nil
 }
 
-func (*Repository) Write(filename string, tc credentialplugin.TokenCache) error {
+func (r *Repository) Save(dir string, key credentialplugin.TokenCacheKey, cache credentialplugin.TokenCache) error {
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return xerrors.Errorf("could not create directory %s: %w", dir, err)
+	}
+	filename := filepath.Join(dir, computeFilename(key))
 	f, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return xerrors.Errorf("could not create file %s: %w", filename, err)
 	}
 	defer f.Close()
 	e := json.NewEncoder(f)
-	if err := e.Encode(&tc); err != nil {
+	if err := e.Encode(&cache); err != nil {
 		return xerrors.Errorf("could not encode json to file %s: %w", filename, err)
 	}
 	return nil
+}
+
+func computeFilename(key credentialplugin.TokenCacheKey) string {
+	s := sha256.New()
+	_, _ = s.Write([]byte(key.IssuerURL))
+	_, _ = s.Write([]byte{0x00})
+	_, _ = s.Write([]byte(key.ClientID))
+	return hex.EncodeToString(s.Sum(nil))
 }

--- a/pkg/adaptors/tokencache/tokencache_test.go
+++ b/pkg/adaptors/tokencache/tokencache_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/int128/kubelogin/pkg/models/credentialplugin"
 )
 
-func TestRepository_Read(t *testing.T) {
+func TestRepository_FindByKey(t *testing.T) {
 	var r Repository
 
 	t.Run("Success", func(t *testing.T) {
@@ -23,13 +23,17 @@ func TestRepository_Read(t *testing.T) {
 				t.Errorf("could not clean up the temp dir: %s", err)
 			}
 		}()
+		key := credentialplugin.TokenCacheKey{
+			IssuerURL: "YOUR_ISSUER",
+			ClientID:  "YOUR_CLIENT_ID",
+		}
 		json := `{"id_token":"YOUR_ID_TOKEN","refresh_token":"YOUR_REFRESH_TOKEN"}`
-		filename := filepath.Join(dir, "token-cache")
+		filename := filepath.Join(dir, computeFilename(key))
 		if err := ioutil.WriteFile(filename, []byte(json), 0600); err != nil {
 			t.Fatalf("could not write to the temp file: %s", err)
 		}
 
-		tokenCache, err := r.Read(filename)
+		tokenCache, err := r.FindByKey(dir, key)
 		if err != nil {
 			t.Errorf("err wants nil but %+v", err)
 		}
@@ -40,7 +44,7 @@ func TestRepository_Read(t *testing.T) {
 	})
 }
 
-func TestRepository_Write(t *testing.T) {
+func TestRepository_Save(t *testing.T) {
 	var r Repository
 
 	t.Run("Success", func(t *testing.T) {
@@ -54,12 +58,16 @@ func TestRepository_Write(t *testing.T) {
 			}
 		}()
 
-		filename := filepath.Join(dir, "token-cache")
+		key := credentialplugin.TokenCacheKey{
+			IssuerURL: "YOUR_ISSUER",
+			ClientID:  "YOUR_CLIENT_ID",
+		}
 		tokenCache := credentialplugin.TokenCache{IDToken: "YOUR_ID_TOKEN", RefreshToken: "YOUR_REFRESH_TOKEN"}
-		if err := r.Write(filename, tokenCache); err != nil {
+		if err := r.Save(dir, key, tokenCache); err != nil {
 			t.Errorf("err wants nil but %+v", err)
 		}
 
+		filename := filepath.Join(dir, computeFilename(key))
 		b, err := ioutil.ReadFile(filename)
 		if err != nil {
 			t.Fatalf("could not read the token cache file: %s", err)

--- a/pkg/models/credentialplugin/credential_plugin.go
+++ b/pkg/models/credentialplugin/credential_plugin.go
@@ -3,7 +3,13 @@ package credentialplugin
 
 import "time"
 
-// TokenCache represents a token object cached.
+// TokenCacheKey represents a key of a token cache.
+type TokenCacheKey struct {
+	IssuerURL string
+	ClientID  string
+}
+
+// TokenCache represents a token cache.
 type TokenCache struct {
 	IDToken      string `json:"id_token,omitempty"`
 	RefreshToken string `json:"refresh_token,omitempty"`

--- a/pkg/usecases/credentialplugin/get_token_test.go
+++ b/pkg/usecases/credentialplugin/get_token_test.go
@@ -23,16 +23,16 @@ func TestGetToken_Do(t *testing.T) {
 		defer ctrl.Finish()
 		ctx := context.TODO()
 		in := usecases.GetTokenIn{
-			IssuerURL:          "https://accounts.google.com",
-			ClientID:           "YOUR_CLIENT_ID",
-			ClientSecret:       "YOUR_CLIENT_SECRET",
-			TokenCacheFilename: "/path/to/token-cache",
-			ListenPort:         []int{10000},
-			SkipOpenBrowser:    true,
-			Username:           "USER",
-			Password:           "PASS",
-			CACertFilename:     "/path/to/cert",
-			SkipTLSVerify:      true,
+			IssuerURL:       "https://accounts.google.com",
+			ClientID:        "YOUR_CLIENT_ID",
+			ClientSecret:    "YOUR_CLIENT_SECRET",
+			TokenCacheDir:   "/path/to/token-cache",
+			ListenPort:      []int{10000},
+			SkipOpenBrowser: true,
+			Username:        "USER",
+			Password:        "PASS",
+			CACertFilename:  "/path/to/cert",
+			SkipTLSVerify:   true,
 		}
 		mockAuthentication := mock_usecases.NewMockAuthentication(ctrl)
 		mockAuthentication.EXPECT().
@@ -57,13 +57,21 @@ func TestGetToken_Do(t *testing.T) {
 			}, nil)
 		tokenCacheRepository := mock_adaptors.NewMockTokenCacheRepository(ctrl)
 		tokenCacheRepository.EXPECT().
-			Read("/path/to/token-cache").
+			FindByKey("/path/to/token-cache", credentialplugin.TokenCacheKey{
+				IssuerURL: "https://accounts.google.com",
+				ClientID:  "YOUR_CLIENT_ID",
+			}).
 			Return(nil, xerrors.New("file not found"))
 		tokenCacheRepository.EXPECT().
-			Write("/path/to/token-cache", credentialplugin.TokenCache{
-				IDToken:      "YOUR_ID_TOKEN",
-				RefreshToken: "YOUR_REFRESH_TOKEN",
-			})
+			Save("/path/to/token-cache",
+				credentialplugin.TokenCacheKey{
+					IssuerURL: "https://accounts.google.com",
+					ClientID:  "YOUR_CLIENT_ID",
+				},
+				credentialplugin.TokenCache{
+					IDToken:      "YOUR_ID_TOKEN",
+					RefreshToken: "YOUR_REFRESH_TOKEN",
+				})
 		credentialPluginInteraction := mock_adaptors.NewMockCredentialPluginInteraction(ctrl)
 		credentialPluginInteraction.EXPECT().
 			Write(credentialplugin.Output{
@@ -86,10 +94,10 @@ func TestGetToken_Do(t *testing.T) {
 		defer ctrl.Finish()
 		ctx := context.TODO()
 		in := usecases.GetTokenIn{
-			IssuerURL:          "https://accounts.google.com",
-			ClientID:           "YOUR_CLIENT_ID",
-			ClientSecret:       "YOUR_CLIENT_SECRET",
-			TokenCacheFilename: "/path/to/token-cache",
+			IssuerURL:     "https://accounts.google.com",
+			ClientID:      "YOUR_CLIENT_ID",
+			ClientSecret:  "YOUR_CLIENT_SECRET",
+			TokenCacheDir: "/path/to/token-cache",
 		}
 		mockAuthentication := mock_usecases.NewMockAuthentication(ctrl)
 		mockAuthentication.EXPECT().
@@ -109,7 +117,10 @@ func TestGetToken_Do(t *testing.T) {
 			}, nil)
 		tokenCacheRepository := mock_adaptors.NewMockTokenCacheRepository(ctrl)
 		tokenCacheRepository.EXPECT().
-			Read("/path/to/token-cache").
+			FindByKey("/path/to/token-cache", credentialplugin.TokenCacheKey{
+				IssuerURL: "https://accounts.google.com",
+				ClientID:  "YOUR_CLIENT_ID",
+			}).
 			Return(&credentialplugin.TokenCache{
 				IDToken: "VALID_ID_TOKEN",
 			}, nil)
@@ -135,10 +146,10 @@ func TestGetToken_Do(t *testing.T) {
 		defer ctrl.Finish()
 		ctx := context.TODO()
 		in := usecases.GetTokenIn{
-			IssuerURL:          "https://accounts.google.com",
-			ClientID:           "YOUR_CLIENT_ID",
-			ClientSecret:       "YOUR_CLIENT_SECRET",
-			TokenCacheFilename: "/path/to/token-cache",
+			IssuerURL:     "https://accounts.google.com",
+			ClientID:      "YOUR_CLIENT_ID",
+			ClientSecret:  "YOUR_CLIENT_SECRET",
+			TokenCacheDir: "/path/to/token-cache",
 		}
 		mockAuthentication := mock_usecases.NewMockAuthentication(ctrl)
 		mockAuthentication.EXPECT().
@@ -152,7 +163,10 @@ func TestGetToken_Do(t *testing.T) {
 			Return(nil, xerrors.New("authentication error"))
 		tokenCacheRepository := mock_adaptors.NewMockTokenCacheRepository(ctrl)
 		tokenCacheRepository.EXPECT().
-			Read("/path/to/token-cache").
+			FindByKey("/path/to/token-cache", credentialplugin.TokenCacheKey{
+				IssuerURL: "https://accounts.google.com",
+				ClientID:  "YOUR_CLIENT_ID",
+			}).
 			Return(nil, xerrors.New("file not found"))
 		u := GetToken{
 			Authentication:       mockAuthentication,

--- a/pkg/usecases/interfaces.go
+++ b/pkg/usecases/interfaces.go
@@ -38,17 +38,17 @@ type GetToken interface {
 
 // GetTokenIn represents an input DTO of the GetToken use-case.
 type GetTokenIn struct {
-	IssuerURL          string
-	ClientID           string
-	ClientSecret       string
-	ExtraScopes        []string // optional
-	SkipOpenBrowser    bool
-	ListenPort         []int
-	Username           string // If set, perform the resource owner password credentials grant
-	Password           string // If empty, read a password using Env.ReadPassword()
-	CACertFilename     string // If set, use the CA cert
-	SkipTLSVerify      bool
-	TokenCacheFilename string
+	IssuerURL       string
+	ClientID        string
+	ClientSecret    string
+	ExtraScopes     []string // optional
+	SkipOpenBrowser bool
+	ListenPort      []int
+	Username        string // If set, perform the resource owner password credentials grant
+	Password        string // If empty, read a password using Env.ReadPassword()
+	CACertFilename  string // If set, use the CA cert
+	SkipTLSVerify   bool
+	TokenCacheDir   string
 }
 
 type Authentication interface {


### PR DESCRIPTION
This changes token cache to a directory from a file. It allows handling multiple issuers. A token cache will saved per an issuer and client ID.