### PR TITLE
Refactor: use channel to wait for opening browser

### DIFF
--- a/e2e_test/credetial_plugin_test.go
+++ b/e2e_test/credetial_plugin_test.go
@@ -62,21 +62,21 @@ func TestCmd_Run_CredentialPlugin(t *testing.T) {
 				}
 			})
 
-		req := startBrowserRequest(t, ctx, nil)
-		runGetTokenCmd(t, ctx, req, credentialPluginInteraction,
+		runGetTokenCmd(t, ctx,
+			openBrowserOnReadyFunc(t, ctx, nil),
+			credentialPluginInteraction,
 			"--skip-open-browser",
 			"--listen-port", "0",
 			"--token-cache-dir", cacheDir,
 			"--oidc-issuer-url", serverURL,
 			"--oidc-client-id", "kubernetes",
 		)
-		req.wait()
 	})
 }
 
-func runGetTokenCmd(t *testing.T, ctx context.Context, s auth.ShowLocalServerURLInterface, interaction credentialplugin.Interface, args ...string) {
+func runGetTokenCmd(t *testing.T, ctx context.Context, localServerReadyFunc auth.LocalServerReadyFunc, interaction credentialplugin.Interface, args ...string) {
 	t.Helper()
-	cmd := di.NewCmdForHeadless(mock_logger.New(t), s, interaction)
+	cmd := di.NewCmdForHeadless(mock_logger.New(t), localServerReadyFunc, interaction)
 	exitCode := cmd.Run(ctx, append([]string{"kubelogin", "get-token", "--v=1"}, args...), "HEAD")
 	if exitCode != 0 {
 		t.Errorf("exit status wants 0 but %d", exitCode)

--- a/go.mod
+++ b/go.mod
@@ -8,13 +8,14 @@ require (
 	github.com/go-test/deep v1.0.3
 	github.com/golang/mock v1.3.1
 	github.com/google/wire v0.3.0
-	github.com/int128/oauth2cli v1.4.1
+	github.com/int128/oauth2cli v1.5.0
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.3
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
 	gopkg.in/square/go-jose.v2 v2.3.1 // indirect
 	gopkg.in/yaml.v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/int128/oauth2cli v1.4.1 h1:IsaYMafEDS1jyArxYdmksw+nMsNxiYCQzdkPj3QF9BY=
 github.com/int128/oauth2cli v1.4.1/go.mod h1:CMJjyUSgKiobye1M/9byFACOjtB2LRo2mo7boklEKlI=
+github.com/int128/oauth2cli v1.5.0 h1:EOBMCWfroql1hPqPhP+EtDhgO7y6ClFZ/NwJEpBCo1s=
+github.com/int128/oauth2cli v1.5.0/go.mod h1:ivzuzt+k+bpwLI1Mb1bRq8PiBvwLBsO8L7tX2F9iKKA=
 github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be h1:AHimNtVIpiBjPUhEF5KNCkrUyqTSA5zWUl8sQ2bfGBE=
 github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/pkg/adaptors/env/mock_env/mock_env.go
+++ b/pkg/adaptors/env/mock_env/mock_env.go
@@ -32,6 +32,18 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 	return m.recorder
 }
 
+// OpenBrowser mocks base method
+func (m *MockInterface) OpenBrowser(arg0 string) error {
+	ret := m.ctrl.Call(m, "OpenBrowser", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// OpenBrowser indicates an expected call of OpenBrowser
+func (mr *MockInterfaceMockRecorder) OpenBrowser(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenBrowser", reflect.TypeOf((*MockInterface)(nil).OpenBrowser), arg0)
+}
+
 // ReadPassword mocks base method
 func (m *MockInterface) ReadPassword(arg0 string) (string, error) {
 	ret := m.ctrl.Call(m, "ReadPassword", arg0)

--- a/pkg/adaptors/oidc/mock_oidc/mock_oidc.go
+++ b/pkg/adaptors/oidc/mock_oidc/mock_oidc.go
@@ -71,35 +71,35 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 }
 
 // AuthenticateByCode mocks base method
-func (m *MockInterface) AuthenticateByCode(arg0 context.Context, arg1 oidc.AuthenticateByCodeIn) (*oidc.AuthenticateOut, error) {
-	ret := m.ctrl.Call(m, "AuthenticateByCode", arg0, arg1)
-	ret0, _ := ret[0].(*oidc.AuthenticateOut)
+func (m *MockInterface) AuthenticateByCode(arg0 context.Context, arg1 []int, arg2 chan<- string) (*oidc.TokenSet, error) {
+	ret := m.ctrl.Call(m, "AuthenticateByCode", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*oidc.TokenSet)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AuthenticateByCode indicates an expected call of AuthenticateByCode
-func (mr *MockInterfaceMockRecorder) AuthenticateByCode(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthenticateByCode", reflect.TypeOf((*MockInterface)(nil).AuthenticateByCode), arg0, arg1)
+func (mr *MockInterfaceMockRecorder) AuthenticateByCode(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthenticateByCode", reflect.TypeOf((*MockInterface)(nil).AuthenticateByCode), arg0, arg1, arg2)
 }
 
 // AuthenticateByPassword mocks base method
-func (m *MockInterface) AuthenticateByPassword(arg0 context.Context, arg1 oidc.AuthenticateByPasswordIn) (*oidc.AuthenticateOut, error) {
-	ret := m.ctrl.Call(m, "AuthenticateByPassword", arg0, arg1)
-	ret0, _ := ret[0].(*oidc.AuthenticateOut)
+func (m *MockInterface) AuthenticateByPassword(arg0 context.Context, arg1, arg2 string) (*oidc.TokenSet, error) {
+	ret := m.ctrl.Call(m, "AuthenticateByPassword", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*oidc.TokenSet)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AuthenticateByPassword indicates an expected call of AuthenticateByPassword
-func (mr *MockInterfaceMockRecorder) AuthenticateByPassword(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthenticateByPassword", reflect.TypeOf((*MockInterface)(nil).AuthenticateByPassword), arg0, arg1)
+func (mr *MockInterfaceMockRecorder) AuthenticateByPassword(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthenticateByPassword", reflect.TypeOf((*MockInterface)(nil).AuthenticateByPassword), arg0, arg1, arg2)
 }
 
 // Refresh mocks base method
-func (m *MockInterface) Refresh(arg0 context.Context, arg1 oidc.RefreshIn) (*oidc.AuthenticateOut, error) {
+func (m *MockInterface) Refresh(arg0 context.Context, arg1 string) (*oidc.TokenSet, error) {
 	ret := m.ctrl.Call(m, "Refresh", arg0, arg1)
-	ret0, _ := ret[0].(*oidc.AuthenticateOut)
+	ret0, _ := ret[0].(*oidc.TokenSet)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/adaptors/oidc/oidc.go
+++ b/pkg/adaptors/oidc/oidc.go
@@ -1,20 +1,10 @@
 package oidc
 
 import (
-	"os"
-
 	"github.com/google/wire"
-	"github.com/pkg/browser"
 )
 
 //go:generate mockgen -destination mock_oidc/mock_oidc.go github.com/int128/kubelogin/pkg/adaptors/oidc FactoryInterface,Interface,DecoderInterface
-
-func init() {
-	// In credential plugin mode, some browser launcher writes a message to stdout
-	// and it may break the credential json for client-go.
-	// This prevents the browser launcher from breaking the credential json.
-	browser.Stdout = os.Stderr
-}
 
 // Set provides an implementation and interface for OIDC.
 var Set = wire.NewSet(

--- a/pkg/di/di.go
+++ b/pkg/di/di.go
@@ -22,7 +22,7 @@ func NewCmd() cmd.Interface {
 	wire.Build(
 		// use-cases
 		auth.Set,
-		auth.ExtraSet,
+		wire.Value(auth.DefaultLocalServerReadyFunc),
 		standalone.Set,
 		credentialPluginUseCase.Set,
 
@@ -39,11 +39,7 @@ func NewCmd() cmd.Interface {
 }
 
 // NewCmdForHeadless returns an instance of adaptors.Cmd for headless testing.
-func NewCmdForHeadless(
-	logger.Interface,
-	auth.ShowLocalServerURLInterface,
-	credentialPluginAdaptor.Interface,
-) cmd.Interface {
+func NewCmdForHeadless(logger.Interface, auth.LocalServerReadyFunc, credentialPluginAdaptor.Interface) cmd.Interface {
 	wire.Build(
 		auth.Set,
 		standalone.Set,

--- a/pkg/di/wire_gen.go
+++ b/pkg/di/wire_gen.go
@@ -27,15 +27,13 @@ func NewCmd() cmd.Interface {
 	}
 	decoder := &oidc.Decoder{}
 	envEnv := &env.Env{}
-	showLocalServerURL := &auth.ShowLocalServerURL{
-		Logger: loggerInterface,
-	}
+	localServerReadyFunc := _wireLocalServerReadyFuncValue
 	authentication := &auth.Authentication{
-		OIDCFactory:        factory,
-		OIDCDecoder:        decoder,
-		Env:                envEnv,
-		Logger:             loggerInterface,
-		ShowLocalServerURL: showLocalServerURL,
+		OIDCFactory:          factory,
+		OIDCDecoder:          decoder,
+		Env:                  envEnv,
+		Logger:               loggerInterface,
+		LocalServerReadyFunc: localServerReadyFunc,
 	}
 	kubeconfigKubeconfig := &kubeconfig.Kubeconfig{}
 	standaloneStandalone := &standalone.Standalone{
@@ -67,18 +65,22 @@ func NewCmd() cmd.Interface {
 	return cmdCmd
 }
 
-func NewCmdForHeadless(loggerInterface logger.Interface, showLocalServerURLInterface auth.ShowLocalServerURLInterface, credentialpluginInterface credentialplugin.Interface) cmd.Interface {
+var (
+	_wireLocalServerReadyFuncValue = auth.DefaultLocalServerReadyFunc
+)
+
+func NewCmdForHeadless(loggerInterface logger.Interface, localServerReadyFunc auth.LocalServerReadyFunc, credentialpluginInterface credentialplugin.Interface) cmd.Interface {
 	factory := &oidc.Factory{
 		Logger: loggerInterface,
 	}
 	decoder := &oidc.Decoder{}
 	envEnv := &env.Env{}
 	authentication := &auth.Authentication{
-		OIDCFactory:        factory,
-		OIDCDecoder:        decoder,
-		Env:                envEnv,
-		Logger:             loggerInterface,
-		ShowLocalServerURL: showLocalServerURLInterface,
+		OIDCFactory:          factory,
+		OIDCDecoder:          decoder,
+		Env:                  envEnv,
+		Logger:               loggerInterface,
+		LocalServerReadyFunc: localServerReadyFunc,
 	}
 	kubeconfigKubeconfig := &kubeconfig.Kubeconfig{}
 	standaloneStandalone := &standalone.Standalone{


### PR DESCRIPTION
This bumps https://github.com/int128/oauth2cli to v1.5.0 and replaces the callback with a channel for opening the browser. This simplifies e2e test code.