### PR TITLE
Refactor: fix error handling and improve stability

### DIFF
--- a/e2e_test/standalone_test.go
+++ b/e2e_test/standalone_test.go
@@ -33,7 +33,7 @@ var (
 // 4. Verify the kubeconfig.
 //
 func TestCmd_Run_Standalone(t *testing.T) {
-	timeout := 1 * time.Second
+	timeout := 5 * time.Second
 
 	type testParameter struct {
 		startServer                       func(t *testing.T, h http.Handler) (string, localserver.Shutdowner)

--- a/e2e_test/standalone_test.go
+++ b/e2e_test/standalone_test.go
@@ -57,7 +57,7 @@ func TestCmd_Run_Standalone(t *testing.T) {
 	runTest := func(t *testing.T, p testParameter) {
 		t.Run("Defaults", func(t *testing.T) {
 			t.Parallel()
-			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 			defer cancel()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
@@ -85,7 +85,7 @@ func TestCmd_Run_Standalone(t *testing.T) {
 
 		t.Run("ResourceOwnerPasswordCredentials", func(t *testing.T) {
 			t.Parallel()
-			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 			defer cancel()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
@@ -116,7 +116,7 @@ func TestCmd_Run_Standalone(t *testing.T) {
 
 		t.Run("HasValidToken", func(t *testing.T) {
 			t.Parallel()
-			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 			defer cancel()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
@@ -145,7 +145,7 @@ func TestCmd_Run_Standalone(t *testing.T) {
 
 		t.Run("HasValidRefreshToken", func(t *testing.T) {
 			t.Parallel()
-			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 			defer cancel()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
@@ -178,7 +178,7 @@ func TestCmd_Run_Standalone(t *testing.T) {
 
 		t.Run("HasExpiredRefreshToken", func(t *testing.T) {
 			t.Parallel()
-			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 			defer cancel()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
@@ -218,7 +218,7 @@ func TestCmd_Run_Standalone(t *testing.T) {
 
 	t.Run("env:KUBECONFIG", func(t *testing.T) {
 		t.Parallel()
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 		defer cancel()
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -245,7 +245,7 @@ func TestCmd_Run_Standalone(t *testing.T) {
 
 	t.Run("ExtraScopes", func(t *testing.T) {
 		t.Parallel()
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 		defer cancel()
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()

--- a/pkg/adaptors/env/env.go
+++ b/pkg/adaptors/env/env.go
@@ -36,7 +36,7 @@ type Env struct{}
 
 // ReadPassword reads a password from the stdin without echo back.
 func (*Env) ReadPassword(prompt string) (string, error) {
-	if _, err := fmt.Fprint(os.Stderr, "Password: "); err != nil {
+	if _, err := fmt.Fprint(os.Stderr, prompt); err != nil {
 		return "", xerrors.Errorf("could not write the prompt: %w", err)
 	}
 	b, err := terminal.ReadPassword(int(syscall.Stdin))

--- a/pkg/usecases/auth/auth_test.go
+++ b/pkg/usecases/auth/auth_test.go
@@ -19,11 +19,12 @@ func TestAuthentication_Do(t *testing.T) {
 	dummyTokenClaims := map[string]string{"sub": "YOUR_SUBJECT"}
 	pastTime := time.Now().Add(-time.Hour)  //TODO: inject time service
 	futureTime := time.Now().Add(time.Hour) //TODO: inject time service
+	timeout := 5 * time.Second
 
 	t.Run("AuthorizationCodeFlow", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-		ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 		defer cancel()
 		in := Input{
 			ListenPort:      []int{10000},
@@ -79,7 +80,7 @@ func TestAuthentication_Do(t *testing.T) {
 	t.Run("AuthorizationCodeFlow/OpenBrowser", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-		ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 		defer cancel()
 		in := Input{
 			ListenPort: []int{10000},
@@ -132,7 +133,7 @@ func TestAuthentication_Do(t *testing.T) {
 	t.Run("ResourceOwnerPasswordCredentialsFlow/UsePassword", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-		ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 		defer cancel()
 		in := Input{
 			Username:       "USER",
@@ -185,7 +186,7 @@ func TestAuthentication_Do(t *testing.T) {
 	t.Run("ResourceOwnerPasswordCredentialsFlow/AskPassword", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-		ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 		defer cancel()
 		in := Input{
 			Username: "USER",
@@ -236,7 +237,7 @@ func TestAuthentication_Do(t *testing.T) {
 	t.Run("ResourceOwnerPasswordCredentialsFlow/AskPasswordError", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-		ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 		defer cancel()
 		in := Input{
 			Username: "USER",
@@ -270,7 +271,7 @@ func TestAuthentication_Do(t *testing.T) {
 	t.Run("HasValidIDToken", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-		ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 		defer cancel()
 		in := Input{
 			OIDCConfig: kubeconfig.OIDCConfig{
@@ -311,7 +312,7 @@ func TestAuthentication_Do(t *testing.T) {
 	t.Run("HasValidRefreshToken", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-		ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 		defer cancel()
 		in := Input{
 			OIDCConfig: kubeconfig.OIDCConfig{
@@ -369,7 +370,7 @@ func TestAuthentication_Do(t *testing.T) {
 	t.Run("HasExpiredRefreshToken", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-		ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 		defer cancel()
 		in := Input{
 			ListenPort:      []int{10000},

--- a/pkg/usecases/auth/auth_test.go
+++ b/pkg/usecases/auth/auth_test.go
@@ -23,7 +23,8 @@ func TestAuthentication_Do(t *testing.T) {
 	t.Run("AuthorizationCodeFlow", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-		ctx := context.TODO()
+		ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+		defer cancel()
 		in := Input{
 			ListenPort:      []int{10000},
 			SkipOpenBrowser: true,
@@ -36,7 +37,10 @@ func TestAuthentication_Do(t *testing.T) {
 		}
 		mockOIDCClient := mock_oidc.NewMockInterface(ctrl)
 		mockOIDCClient.EXPECT().
-			AuthenticateByCode(ctx, []int{10000}, gomock.Any()).
+			AuthenticateByCode(gomock.Any(), []int{10000}, gomock.Any()).
+			Do(func(_ context.Context, _ []int, readyChan chan<- string) {
+				readyChan <- "LOCAL_SERVER_URL"
+			}).
 			Return(&oidc.TokenSet{
 				IDToken:        "YOUR_ID_TOKEN",
 				RefreshToken:   "YOUR_REFRESH_TOKEN",
@@ -75,7 +79,8 @@ func TestAuthentication_Do(t *testing.T) {
 	t.Run("AuthorizationCodeFlow/OpenBrowser", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-		ctx := context.TODO()
+		ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+		defer cancel()
 		in := Input{
 			ListenPort: []int{10000},
 			OIDCConfig: kubeconfig.OIDCConfig{
@@ -85,7 +90,7 @@ func TestAuthentication_Do(t *testing.T) {
 		}
 		mockOIDCClient := mock_oidc.NewMockInterface(ctrl)
 		mockOIDCClient.EXPECT().
-			AuthenticateByCode(ctx, []int{10000}, gomock.Any()).
+			AuthenticateByCode(gomock.Any(), []int{10000}, gomock.Any()).
 			Do(func(_ context.Context, _ []int, readyChan chan<- string) {
 				readyChan <- "LOCAL_SERVER_URL"
 			}).
@@ -127,7 +132,8 @@ func TestAuthentication_Do(t *testing.T) {
 	t.Run("ResourceOwnerPasswordCredentialsFlow/UsePassword", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-		ctx := context.TODO()
+		ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+		defer cancel()
 		in := Input{
 			Username:       "USER",
 			Password:       "PASS",
@@ -140,7 +146,7 @@ func TestAuthentication_Do(t *testing.T) {
 		}
 		mockOIDCClient := mock_oidc.NewMockInterface(ctrl)
 		mockOIDCClient.EXPECT().
-			AuthenticateByPassword(ctx, "USER", "PASS").
+			AuthenticateByPassword(gomock.Any(), "USER", "PASS").
 			Return(&oidc.TokenSet{
 				IDToken:        "YOUR_ID_TOKEN",
 				RefreshToken:   "YOUR_REFRESH_TOKEN",
@@ -179,7 +185,8 @@ func TestAuthentication_Do(t *testing.T) {
 	t.Run("ResourceOwnerPasswordCredentialsFlow/AskPassword", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-		ctx := context.TODO()
+		ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+		defer cancel()
 		in := Input{
 			Username: "USER",
 			OIDCConfig: kubeconfig.OIDCConfig{
@@ -189,7 +196,7 @@ func TestAuthentication_Do(t *testing.T) {
 		}
 		mockOIDCClient := mock_oidc.NewMockInterface(ctrl)
 		mockOIDCClient.EXPECT().
-			AuthenticateByPassword(ctx, "USER", "PASS").
+			AuthenticateByPassword(gomock.Any(), "USER", "PASS").
 			Return(&oidc.TokenSet{
 				IDToken:        "YOUR_ID_TOKEN",
 				RefreshToken:   "YOUR_REFRESH_TOKEN",
@@ -229,7 +236,8 @@ func TestAuthentication_Do(t *testing.T) {
 	t.Run("ResourceOwnerPasswordCredentialsFlow/AskPasswordError", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-		ctx := context.TODO()
+		ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+		defer cancel()
 		in := Input{
 			Username: "USER",
 			OIDCConfig: kubeconfig.OIDCConfig{
@@ -262,7 +270,8 @@ func TestAuthentication_Do(t *testing.T) {
 	t.Run("HasValidIDToken", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-		ctx := context.TODO()
+		ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+		defer cancel()
 		in := Input{
 			OIDCConfig: kubeconfig.OIDCConfig{
 				ClientID:     "YOUR_CLIENT_ID",
@@ -302,7 +311,8 @@ func TestAuthentication_Do(t *testing.T) {
 	t.Run("HasValidRefreshToken", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-		ctx := context.TODO()
+		ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+		defer cancel()
 		in := Input{
 			OIDCConfig: kubeconfig.OIDCConfig{
 				ClientID:     "YOUR_CLIENT_ID",
@@ -359,9 +369,11 @@ func TestAuthentication_Do(t *testing.T) {
 	t.Run("HasExpiredRefreshToken", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-		ctx := context.TODO()
+		ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+		defer cancel()
 		in := Input{
-			ListenPort: []int{10000},
+			ListenPort:      []int{10000},
+			SkipOpenBrowser: true,
 			OIDCConfig: kubeconfig.OIDCConfig{
 				ClientID:     "YOUR_CLIENT_ID",
 				ClientSecret: "YOUR_CLIENT_SECRET",
@@ -382,7 +394,10 @@ func TestAuthentication_Do(t *testing.T) {
 			Refresh(ctx, "EXPIRED_REFRESH_TOKEN").
 			Return(nil, xerrors.New("token has expired"))
 		mockOIDCClient.EXPECT().
-			AuthenticateByCode(ctx, []int{10000}, gomock.Any()).
+			AuthenticateByCode(gomock.Any(), []int{10000}, gomock.Any()).
+			Do(func(_ context.Context, _ []int, readyChan chan<- string) {
+				readyChan <- "LOCAL_SERVER_URL"
+			}).
 			Return(&oidc.TokenSet{
 				IDToken:        "NEW_ID_TOKEN",
 				RefreshToken:   "NEW_REFRESH_TOKEN",


### PR DESCRIPTION
* b2ac9f1 Use longer timeout to reveal concurrency design failure
* 540222e Do not ignore error when context has been cancelled
* 9381403 Fix ReadPassword() does not respect argument
