### PR TITLE
Add --grant-type option and username prompt for ROPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,14 @@ Flags:
       --oidc-client-id string          Client ID of the provider (mandatory)
       --oidc-client-secret string      Client secret of the provider
       --oidc-extra-scope strings       Scopes to request to the provider
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --token-cache-dir string         Path to a directory for caching tokens (default "~/.kube/cache/oidc-login")
+      --grant-type string              The authorization grant type to use. One of (auto|authcode|password) (default "auto")
       --listen-port ints               Port to bind to the local server. If multiple ports are given, it will try the ports in order (default [8000,18000])
       --skip-open-browser              If true, it does not open the browser on authentication
       --username string                If set, perform the resource owner password credentials grant
       --password string                If set, use the password instead of asking it
-      --certificate-authority string   Path to a cert file for the certificate authority
-      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --token-cache-dir string         Path to a directory for caching tokens (default "~/.kube/cache/oidc-login")
   -h, --help                           help for get-token
 
 Global Flags:
@@ -155,21 +156,39 @@ You can change the ports by the option:
 
 #### Resource owner password credentials grant flow
 
-As well as you can use the resource owner password credentials grant flow.
-Keycloak supports this flow but you need to explicitly enable the "Direct Access Grants" feature in the client settings.
-Most OIDC providers do not support this flow.
+Kubelogin performs the resource owner password credentials grant flow
+when `--grant-type=password` or `--username` is set.
 
-You can pass the username and password:
+Note that most OIDC providers do not support this flow.
+Keycloak supports this flow but you need to explicitly enable the "Direct Access Grants" feature in the client settings.
+
+You can set the username and password.
 
 ```yaml
       - --username USERNAME
       - --password PASSWORD
 ```
 
-If the password is not set, kubelogin will show the prompt.
+If the password is not set, kubelogin will show the prompt for the password.
+
+```yaml
+      - --username USERNAME
+```
 
 ```
-% kubelogin --username USER
+% kubectl get pods
+Password:
+```
+
+If the username is not set, kubelogin will show the prompt for the username and password.
+
+```yaml
+      - --grant-type=password
+```
+
+```
+% kubectl get pods
+Username: foo
 Password:
 ```
 

--- a/docs/standalone-mode.md
+++ b/docs/standalone-mode.md
@@ -102,12 +102,13 @@ Flags:
       --kubeconfig string                Path to the kubeconfig file
       --context string                   The name of the kubeconfig context to use
       --user string                      The name of the kubeconfig user to use. Prior to --context
+      --certificate-authority string     Path to a cert file for the certificate authority
+      --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --grant-type string                The authorization grant type to use. One of (auto|authcode|password) (default "auto")
       --listen-port ints                 Port to bind to the local server. If multiple ports are given, it will try the ports in order (default [8000,18000])
       --skip-open-browser                If true, it does not open the browser on authentication
       --username string                  If set, perform the resource owner password credentials grant
       --password string                  If set, use the password instead of asking it
-      --certificate-authority string     Path to a cert file for the certificate authority
-      --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --add_dir_header                   If true, adds the file directory to the header
       --alsologtostderr                  log to standard error as well as files
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)

--- a/pkg/adaptors/cmd/get_token.go
+++ b/pkg/adaptors/cmd/get_token.go
@@ -57,7 +57,10 @@ func (cmd *GetToken) New(ctx context.Context) *cobra.Command {
 			return nil
 		},
 		RunE: func(*cobra.Command, []string) error {
-			authCodeOption, ropcOption := o.authenticationOptions.toUseCaseOptions()
+			authCodeOption, ropcOption, err := o.authenticationOptions.toUseCaseOptions()
+			if err != nil {
+				return xerrors.Errorf("error: %w", err)
+			}
 			in := credentialplugin.Input{
 				IssuerURL:      o.IssuerURL,
 				ClientID:       o.ClientID,

--- a/pkg/adaptors/cmd/setup.go
+++ b/pkg/adaptors/cmd/setup.go
@@ -42,7 +42,10 @@ func (cmd *Setup) New(ctx context.Context) *cobra.Command {
 		Short: "Show the setup instruction",
 		Args:  cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {
-			authCodeOption, ropcOption := o.authenticationOptions.toUseCaseOptions()
+			authCodeOption, ropcOption, err := o.authenticationOptions.toUseCaseOptions()
+			if err != nil {
+				return xerrors.Errorf("error: %w", err)
+			}
 			in := setup.Stage2Input{
 				IssuerURL:      o.IssuerURL,
 				ClientID:       o.ClientID,

--- a/pkg/adaptors/env/mock_env/mock_env.go
+++ b/pkg/adaptors/env/mock_env/mock_env.go
@@ -34,6 +34,7 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 
 // OpenBrowser mocks base method
 func (m *MockInterface) OpenBrowser(arg0 string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OpenBrowser", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -41,11 +42,13 @@ func (m *MockInterface) OpenBrowser(arg0 string) error {
 
 // OpenBrowser indicates an expected call of OpenBrowser
 func (mr *MockInterfaceMockRecorder) OpenBrowser(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenBrowser", reflect.TypeOf((*MockInterface)(nil).OpenBrowser), arg0)
 }
 
 // ReadPassword mocks base method
 func (m *MockInterface) ReadPassword(arg0 string) (string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadPassword", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -54,5 +57,21 @@ func (m *MockInterface) ReadPassword(arg0 string) (string, error) {
 
 // ReadPassword indicates an expected call of ReadPassword
 func (mr *MockInterfaceMockRecorder) ReadPassword(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPassword", reflect.TypeOf((*MockInterface)(nil).ReadPassword), arg0)
+}
+
+// ReadString mocks base method
+func (m *MockInterface) ReadString(arg0 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadString", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadString indicates an expected call of ReadString
+func (mr *MockInterfaceMockRecorder) ReadString(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadString", reflect.TypeOf((*MockInterface)(nil).ReadString), arg0)
 }

--- a/pkg/usecases/authentication/authentication.go
+++ b/pkg/usecases/authentication/authentication.go
@@ -67,6 +67,7 @@ type Output struct {
 	RefreshToken           string
 }
 
+const usernamePrompt = "Username: "
 const passwordPrompt = "Password: "
 
 // Authentication provides the internal use-case of authentication.
@@ -200,6 +201,13 @@ func (u *Authentication) doAuthCodeFlow(ctx context.Context, in *AuthCodeOption,
 
 func (u *Authentication) doPasswordCredentialsFlow(ctx context.Context, in *ROPCOption, client oidcclient.Interface) (*Output, error) {
 	u.Logger.V(1).Infof("performing the resource owner password credentials flow")
+	if in.Username == "" {
+		var err error
+		in.Username, err = u.Env.ReadString(usernamePrompt)
+		if err != nil {
+			return nil, xerrors.Errorf("could not get the username: %w", err)
+		}
+	}
 	if in.Password == "" {
 		var err error
 		in.Password, err = u.Env.ReadPassword(passwordPrompt)


### PR DESCRIPTION
This will add support of the username prompt for the resource owner password credentials grant. See #167.