### PR TITLE
Fix token cache is not refreshed when oidc options changed

### DIFF
--- a/e2e_test/credetial_plugin_test.go
+++ b/e2e_test/credetial_plugin_test.go
@@ -111,13 +111,15 @@ func testCredentialPlugin(t *testing.T, cacheDir string, idpTLS keys.Keys, extra
 		serverURL, server := localserver.Start(t, idp.NewHandler(t, service), idpTLS)
 		defer server.Shutdown(t, ctx)
 		idToken := newIDToken(t, serverURL, "YOUR_NONCE", tokenExpiryFuture)
-		setupTokenCache(t, cacheDir, tokencache.Key{
-			IssuerURL: serverURL,
-			ClientID:  "kubernetes",
-		}, tokencache.TokenCache{
-			IDToken:      idToken,
-			RefreshToken: "YOUR_REFRESH_TOKEN",
-		})
+		setupTokenCache(t, cacheDir,
+			tokencache.Key{
+				IssuerURL:      serverURL,
+				ClientID:       "kubernetes",
+				CACertFilename: idpTLS.CACertPath,
+			}, tokencache.TokenCache{
+				IDToken:      idToken,
+				RefreshToken: "YOUR_REFRESH_TOKEN",
+			})
 		credentialPluginInteraction := mock_credentialplugin.NewMockInterface(ctrl)
 		assertCredentialPluginOutput(t, credentialPluginInteraction, &idToken)
 
@@ -128,13 +130,15 @@ func testCredentialPlugin(t *testing.T, cacheDir string, idpTLS keys.Keys, extra
 		}
 		args = append(args, extraArgs...)
 		runGetTokenCmd(t, ctx, openBrowserOnReadyFunc(t, ctx, idpTLS), credentialPluginInteraction, args)
-		assertTokenCache(t, cacheDir, tokencache.Key{
-			IssuerURL: serverURL,
-			ClientID:  "kubernetes",
-		}, tokencache.TokenCache{
-			IDToken:      idToken,
-			RefreshToken: "YOUR_REFRESH_TOKEN",
-		})
+		assertTokenCache(t, cacheDir,
+			tokencache.Key{
+				IssuerURL:      serverURL,
+				ClientID:       "kubernetes",
+				CACertFilename: idpTLS.CACertPath,
+			}, tokencache.TokenCache{
+				IDToken:      idToken,
+				RefreshToken: "YOUR_REFRESH_TOKEN",
+			})
 	})
 
 	t.Run("HasValidRefreshToken", func(t *testing.T) {
@@ -154,13 +158,15 @@ func testCredentialPlugin(t *testing.T, cacheDir string, idpTLS keys.Keys, extra
 		service.EXPECT().Refresh("VALID_REFRESH_TOKEN").
 			Return(idp.NewTokenResponse(validIDToken, "NEW_REFRESH_TOKEN"), nil)
 
-		setupTokenCache(t, cacheDir, tokencache.Key{
-			IssuerURL: serverURL,
-			ClientID:  "kubernetes",
-		}, tokencache.TokenCache{
-			IDToken:      expiredIDToken,
-			RefreshToken: "VALID_REFRESH_TOKEN",
-		})
+		setupTokenCache(t, cacheDir,
+			tokencache.Key{
+				IssuerURL:      serverURL,
+				ClientID:       "kubernetes",
+				CACertFilename: idpTLS.CACertPath,
+			}, tokencache.TokenCache{
+				IDToken:      expiredIDToken,
+				RefreshToken: "VALID_REFRESH_TOKEN",
+			})
 		credentialPluginInteraction := mock_credentialplugin.NewMockInterface(ctrl)
 		assertCredentialPluginOutput(t, credentialPluginInteraction, &validIDToken)
 
@@ -171,13 +177,15 @@ func testCredentialPlugin(t *testing.T, cacheDir string, idpTLS keys.Keys, extra
 		}
 		args = append(args, extraArgs...)
 		runGetTokenCmd(t, ctx, openBrowserOnReadyFunc(t, ctx, idpTLS), credentialPluginInteraction, args)
-		assertTokenCache(t, cacheDir, tokencache.Key{
-			IssuerURL: serverURL,
-			ClientID:  "kubernetes",
-		}, tokencache.TokenCache{
-			IDToken:      validIDToken,
-			RefreshToken: "NEW_REFRESH_TOKEN",
-		})
+		assertTokenCache(t, cacheDir,
+			tokencache.Key{
+				IssuerURL:      serverURL,
+				ClientID:       "kubernetes",
+				CACertFilename: idpTLS.CACertPath,
+			}, tokencache.TokenCache{
+				IDToken:      validIDToken,
+				RefreshToken: "NEW_REFRESH_TOKEN",
+			})
 	})
 
 	t.Run("HasExpiredRefreshToken", func(t *testing.T) {
@@ -198,13 +206,15 @@ func testCredentialPlugin(t *testing.T, cacheDir string, idpTLS keys.Keys, extra
 			Return(nil, &idp.ErrorResponse{Code: "invalid_request", Description: "token has expired"}).
 			MaxTimes(2) // package oauth2 will retry refreshing the token
 
-		setupTokenCache(t, cacheDir, tokencache.Key{
-			IssuerURL: serverURL,
-			ClientID:  "kubernetes",
-		}, tokencache.TokenCache{
-			IDToken:      expiredIDToken,
-			RefreshToken: "EXPIRED_REFRESH_TOKEN",
-		})
+		setupTokenCache(t, cacheDir,
+			tokencache.Key{
+				IssuerURL:      serverURL,
+				ClientID:       "kubernetes",
+				CACertFilename: idpTLS.CACertPath,
+			}, tokencache.TokenCache{
+				IDToken:      expiredIDToken,
+				RefreshToken: "EXPIRED_REFRESH_TOKEN",
+			})
 		credentialPluginInteraction := mock_credentialplugin.NewMockInterface(ctrl)
 		assertCredentialPluginOutput(t, credentialPluginInteraction, &validIDToken)
 
@@ -215,13 +225,15 @@ func testCredentialPlugin(t *testing.T, cacheDir string, idpTLS keys.Keys, extra
 		}
 		args = append(args, extraArgs...)
 		runGetTokenCmd(t, ctx, openBrowserOnReadyFunc(t, ctx, idpTLS), credentialPluginInteraction, args)
-		assertTokenCache(t, cacheDir, tokencache.Key{
-			IssuerURL: serverURL,
-			ClientID:  "kubernetes",
-		}, tokencache.TokenCache{
-			IDToken:      validIDToken,
-			RefreshToken: "YOUR_REFRESH_TOKEN",
-		})
+		assertTokenCache(t, cacheDir,
+			tokencache.Key{
+				IssuerURL:      serverURL,
+				ClientID:       "kubernetes",
+				CACertFilename: idpTLS.CACertPath,
+			}, tokencache.TokenCache{
+				IDToken:      validIDToken,
+				RefreshToken: "YOUR_REFRESH_TOKEN",
+			})
 	})
 
 	t.Run("ExtraScopes", func(t *testing.T) {

--- a/pkg/adaptors/tokencache/tokencache_test.go
+++ b/pkg/adaptors/tokencache/tokencache_test.go
@@ -23,12 +23,20 @@ func TestRepository_FindByKey(t *testing.T) {
 			}
 		}()
 		key := Key{
-			IssuerURL: "YOUR_ISSUER",
-			ClientID:  "YOUR_CLIENT_ID",
+			IssuerURL:      "YOUR_ISSUER",
+			ClientID:       "YOUR_CLIENT_ID",
+			ClientSecret:   "YOUR_CLIENT_SECRET",
+			ExtraScopes:    []string{"openid", "email"},
+			CACertFilename: "/path/to/cert",
+			SkipTLSVerify:  false,
 		}
 		json := `{"id_token":"YOUR_ID_TOKEN","refresh_token":"YOUR_REFRESH_TOKEN"}`
-		filename := filepath.Join(dir, computeFilename(key))
-		if err := ioutil.WriteFile(filename, []byte(json), 0600); err != nil {
+		filename, err := computeFilename(key)
+		if err != nil {
+			t.Errorf("could not compute the key: %s", err)
+		}
+		p := filepath.Join(dir, filename)
+		if err := ioutil.WriteFile(p, []byte(json), 0600); err != nil {
 			t.Fatalf("could not write to the temp file: %s", err)
 		}
 
@@ -58,16 +66,24 @@ func TestRepository_Save(t *testing.T) {
 		}()
 
 		key := Key{
-			IssuerURL: "YOUR_ISSUER",
-			ClientID:  "YOUR_CLIENT_ID",
+			IssuerURL:      "YOUR_ISSUER",
+			ClientID:       "YOUR_CLIENT_ID",
+			ClientSecret:   "YOUR_CLIENT_SECRET",
+			ExtraScopes:    []string{"openid", "email"},
+			CACertFilename: "/path/to/cert",
+			SkipTLSVerify:  false,
 		}
 		tokenCache := TokenCache{IDToken: "YOUR_ID_TOKEN", RefreshToken: "YOUR_REFRESH_TOKEN"}
 		if err := r.Save(dir, key, tokenCache); err != nil {
 			t.Errorf("err wants nil but %+v", err)
 		}
 
-		filename := filepath.Join(dir, computeFilename(key))
-		b, err := ioutil.ReadFile(filename)
+		filename, err := computeFilename(key)
+		if err != nil {
+			t.Errorf("could not compute the key: %s", err)
+		}
+		p := filepath.Join(dir, filename)
+		b, err := ioutil.ReadFile(p)
 		if err != nil {
 			t.Fatalf("could not read the token cache file: %s", err)
 		}

--- a/pkg/usecases/credentialplugin/get_token.go
+++ b/pkg/usecases/credentialplugin/get_token.go
@@ -61,7 +61,14 @@ func (u *GetToken) Do(ctx context.Context, in Input) error {
 
 func (u *GetToken) getTokenFromCacheOrProvider(ctx context.Context, in Input) (*authentication.Output, error) {
 	u.Logger.V(1).Infof("finding a token from cache directory %s", in.TokenCacheDir)
-	cacheKey := tokencache.Key{IssuerURL: in.IssuerURL, ClientID: in.ClientID}
+	cacheKey := tokencache.Key{
+		IssuerURL:      in.IssuerURL,
+		ClientID:       in.ClientID,
+		ClientSecret:   in.ClientSecret,
+		ExtraScopes:    in.ExtraScopes,
+		CACertFilename: in.CACertFilename,
+		SkipTLSVerify:  in.SkipTLSVerify,
+	}
 	cache, err := u.TokenCacheRepository.FindByKey(in.TokenCacheDir, cacheKey)
 	if err != nil {
 		u.Logger.V(1).Infof("could not find a token cache: %s", err)

--- a/pkg/usecases/credentialplugin/get_token_test.go
+++ b/pkg/usecases/credentialplugin/get_token_test.go
@@ -60,16 +60,23 @@ func TestGetToken_Do(t *testing.T) {
 			}, nil)
 		tokenCacheRepository := mock_tokencache.NewMockInterface(ctrl)
 		tokenCacheRepository.EXPECT().
-			FindByKey("/path/to/token-cache", tokencache.Key{
-				IssuerURL: "https://accounts.google.com",
-				ClientID:  "YOUR_CLIENT_ID",
-			}).
+			FindByKey("/path/to/token-cache",
+				tokencache.Key{
+					IssuerURL:      "https://accounts.google.com",
+					ClientID:       "YOUR_CLIENT_ID",
+					ClientSecret:   "YOUR_CLIENT_SECRET",
+					CACertFilename: "/path/to/cert",
+					SkipTLSVerify:  true,
+				}).
 			Return(nil, xerrors.New("file not found"))
 		tokenCacheRepository.EXPECT().
 			Save("/path/to/token-cache",
 				tokencache.Key{
-					IssuerURL: "https://accounts.google.com",
-					ClientID:  "YOUR_CLIENT_ID",
+					IssuerURL:      "https://accounts.google.com",
+					ClientID:       "YOUR_CLIENT_ID",
+					ClientSecret:   "YOUR_CLIENT_SECRET",
+					CACertFilename: "/path/to/cert",
+					SkipTLSVerify:  true,
 				},
 				tokencache.TokenCache{
 					IDToken:      "YOUR_ID_TOKEN",
@@ -126,8 +133,9 @@ func TestGetToken_Do(t *testing.T) {
 		tokenCacheRepository := mock_tokencache.NewMockInterface(ctrl)
 		tokenCacheRepository.EXPECT().
 			FindByKey("/path/to/token-cache", tokencache.Key{
-				IssuerURL: "https://accounts.google.com",
-				ClientID:  "YOUR_CLIENT_ID",
+				IssuerURL:    "https://accounts.google.com",
+				ClientID:     "YOUR_CLIENT_ID",
+				ClientSecret: "YOUR_CLIENT_SECRET",
 			}).
 			Return(&tokencache.TokenCache{
 				IDToken: "VALID_ID_TOKEN",
@@ -177,8 +185,9 @@ func TestGetToken_Do(t *testing.T) {
 		tokenCacheRepository := mock_tokencache.NewMockInterface(ctrl)
 		tokenCacheRepository.EXPECT().
 			FindByKey("/path/to/token-cache", tokencache.Key{
-				IssuerURL: "https://accounts.google.com",
-				ClientID:  "YOUR_CLIENT_ID",
+				IssuerURL:    "https://accounts.google.com",
+				ClientID:     "YOUR_CLIENT_ID",
+				ClientSecret: "YOUR_CLIENT_SECRET",
 			}).
 			Return(nil, xerrors.New("file not found"))
 		u := GetToken{


### PR DESCRIPTION
This will fix the issue that the token cache is not refreshed when different oidc options are given. For example,

1. Run `kubectl get-token --extra-scopes=email`. It will create a token cache.
1. Run `kubectl get-token --extra-scopes=profile`. It will use the token cache but should recreate the token cache.

This will fix #194.