### PR TITLE
Add --listen-address option to bind all interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ Flags:
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --token-cache-dir string         Path to a directory for caching tokens (default "~/.kube/cache/oidc-login")
       --grant-type string              The authorization grant type to use. One of (auto|authcode|authcode-keyboard|password) (default "auto")
-      --listen-port ints               Port to bind to the local server. If multiple ports are given, it will try the ports in order (default [8000,18000])
+      --listen-address strings         Address to bind to the local server. If multiple addresses are given, it will try binding in order (default [127.0.0.1:8000,127.0.0.1:18000])
+      --listen-port ints               (Deprecated: use --listen-address)
       --skip-open-browser              If true, it does not open the browser on authentication
       --username string                If set, perform the resource owner password credentials grant
       --password string                If set, use the password instead of asking it
@@ -183,11 +184,11 @@ You need to register the following redirect URIs to the provider:
 - `http://localhost:8000`
 - `http://localhost:18000` (used if port 8000 is already in use)
 
-You can change the ports by the option:
+You can change the listening address.
 
 ```yaml
-      - --listen-port=12345
-      - --listen-port=23456
+      - --listen-address=127.0.0.1:12345
+      - --listen-address=127.0.0.1:23456
 ```
 
 #### Authorization code flow with keyboard interactive

--- a/docs/standalone-mode.md
+++ b/docs/standalone-mode.md
@@ -105,7 +105,8 @@ Flags:
       --certificate-authority string     Path to a cert file for the certificate authority
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --grant-type string                The authorization grant type to use. One of (auto|authcode|authcode-keyboard|password) (default "auto")
-      --listen-port ints                 Port to bind to the local server. If multiple ports are given, it will try the ports in order (default [8000,18000])
+      --listen-address strings           Address to bind to the local server. If multiple addresses are given, it will try binding in order (default [127.0.0.1:8000,127.0.0.1:18000])
+      --listen-port ints                 (Deprecated: use --listen-address)
       --skip-open-browser                If true, it does not open the browser on authentication
       --username string                  If set, perform the resource owner password credentials grant
       --password string                  If set, use the password instead of asking it

--- a/e2e_test/credetial_plugin_test.go
+++ b/e2e_test/credetial_plugin_test.go
@@ -284,7 +284,7 @@ func runGetTokenCmd(t *testing.T, ctx context.Context, localServerReadyFunc auth
 		"kubelogin", "get-token",
 		"--v=1",
 		"--skip-open-browser",
-		"--listen-port", "0",
+		"--listen-address", "127.0.0.1:0",
 	}, args...), "HEAD")
 	if exitCode != 0 {
 		t.Errorf("exit status wants 0 but %d", exitCode)

--- a/e2e_test/standalone_test.go
+++ b/e2e_test/standalone_test.go
@@ -260,7 +260,7 @@ func runRootCmd(t *testing.T, ctx context.Context, localServerReadyFunc authenti
 	exitCode := cmd.Run(ctx, append([]string{
 		"kubelogin",
 		"--v=1",
-		"--listen-port", "0",
+		"--listen-address", "127.0.0.1:0",
 		"--skip-open-browser",
 	}, args...), "HEAD")
 	if exitCode != 0 {

--- a/pkg/adaptors/cmd/cmd.go
+++ b/pkg/adaptors/cmd/cmd.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 
 	"github.com/google/wire"
@@ -24,15 +23,8 @@ type Interface interface {
 	Run(ctx context.Context, args []string, version string) int
 }
 
-var defaultListenPort = []int{8000, 18000}
+var defaultListenAddress = []string{"127.0.0.1:8000", "127.0.0.1:18000"}
 var defaultTokenCacheDir = homedir.HomeDir() + "/.kube/cache/oidc-login"
-
-func translateListenPortToBindAddress(ports []int) (address []string) {
-	for _, p := range ports {
-		address = append(address, fmt.Sprintf("127.0.0.1:%d", p))
-	}
-	return
-}
 
 // Cmd provides interaction with command line interface (CLI).
 type Cmd struct {

--- a/pkg/adaptors/cmd/cmd_test.go
+++ b/pkg/adaptors/cmd/cmd_test.go
@@ -27,7 +27,37 @@ func TestCmd_Run(t *testing.T) {
 				in: standalone.Input{
 					GrantOptionSet: authentication.GrantOptionSet{
 						AuthCodeOption: &authentication.AuthCodeOption{
-							BindAddress: []string{"127.0.0.1:8000", "127.0.0.1:18000"},
+							BindAddress: defaultListenAddress,
+						},
+					},
+				},
+			},
+			"when --listen-port is set, it should convert the port to address": {
+				args: []string{
+					executable,
+					"--listen-port", "10080",
+					"--listen-port", "20080",
+				},
+				in: standalone.Input{
+					GrantOptionSet: authentication.GrantOptionSet{
+						AuthCodeOption: &authentication.AuthCodeOption{
+							BindAddress: []string{"127.0.0.1:10080", "127.0.0.1:20080"},
+						},
+					},
+				},
+			},
+			"when --listen-port is set, it should ignore --listen-address flags": {
+				args: []string{
+					executable,
+					"--listen-port", "10080",
+					"--listen-port", "20080",
+					"--listen-address", "127.0.0.1:30080",
+					"--listen-address", "127.0.0.1:40080",
+				},
+				in: standalone.Input{
+					GrantOptionSet: authentication.GrantOptionSet{
+						AuthCodeOption: &authentication.AuthCodeOption{
+							BindAddress: []string{"127.0.0.1:10080", "127.0.0.1:20080"},
 						},
 					},
 				},
@@ -41,8 +71,8 @@ func TestCmd_Run(t *testing.T) {
 					"--insecure-skip-tls-verify",
 					"-v1",
 					"--grant-type", "authcode",
-					"--listen-port", "10080",
-					"--listen-port", "20080",
+					"--listen-address", "127.0.0.1:10080",
+					"--listen-address", "127.0.0.1:20080",
 					"--skip-open-browser",
 					"--username", "USER",
 					"--password", "PASS",
@@ -74,8 +104,8 @@ func TestCmd_Run(t *testing.T) {
 			"GrantType=password": {
 				args: []string{executable,
 					"--grant-type", "password",
-					"--listen-port", "10080",
-					"--listen-port", "20080",
+					"--listen-address", "127.0.0.1:10080",
+					"--listen-address", "127.0.0.1:20080",
 					"--username", "USER",
 					"--password", "PASS",
 				},
@@ -90,8 +120,8 @@ func TestCmd_Run(t *testing.T) {
 			},
 			"GrantType=auto": {
 				args: []string{executable,
-					"--listen-port", "10080",
-					"--listen-port", "20080",
+					"--listen-address", "127.0.0.1:10080",
+					"--listen-address", "127.0.0.1:20080",
 					"--username", "USER",
 					"--password", "PASS",
 				},
@@ -178,8 +208,8 @@ func TestCmd_Run(t *testing.T) {
 					"--insecure-skip-tls-verify",
 					"-v1",
 					"--grant-type", "authcode",
-					"--listen-port", "10080",
-					"--listen-port", "20080",
+					"--listen-address", "127.0.0.1:10080",
+					"--listen-address", "127.0.0.1:20080",
 					"--skip-open-browser",
 					"--username", "USER",
 					"--password", "PASS",
@@ -222,8 +252,8 @@ func TestCmd_Run(t *testing.T) {
 					"--oidc-issuer-url", "https://issuer.example.com",
 					"--oidc-client-id", "YOUR_CLIENT_ID",
 					"--grant-type", "password",
-					"--listen-port", "10080",
-					"--listen-port", "20080",
+					"--listen-address", "127.0.0.1:10080",
+					"--listen-address", "127.0.0.1:20080",
 					"--username", "USER",
 					"--password", "PASS",
 				},
@@ -244,8 +274,8 @@ func TestCmd_Run(t *testing.T) {
 					"get-token",
 					"--oidc-issuer-url", "https://issuer.example.com",
 					"--oidc-client-id", "YOUR_CLIENT_ID",
-					"--listen-port", "10080",
-					"--listen-port", "20080",
+					"--listen-address", "127.0.0.1:10080",
+					"--listen-address", "127.0.0.1:20080",
 					"--username", "USER",
 					"--password", "PASS",
 				},

--- a/pkg/adaptors/cmd/setup.go
+++ b/pkg/adaptors/cmd/setup.go
@@ -55,8 +55,8 @@ func (cmd *Setup) New(ctx context.Context) *cobra.Command {
 				SkipTLSVerify:  o.SkipTLSVerify,
 				GrantOptionSet: grantOptionSet,
 			}
-			if c.Flags().Lookup("listen-port").Changed {
-				in.ListenPortArgs = o.authenticationOptions.ListenPort
+			if c.Flags().Lookup("listen-address").Changed {
+				in.ListenAddressArgs = o.authenticationOptions.ListenAddress
 			}
 			if in.IssuerURL == "" || in.ClientID == "" {
 				cmd.Setup.DoStage1()

--- a/pkg/usecases/setup/stage2.go
+++ b/pkg/usecases/setup/stage2.go
@@ -2,7 +2,6 @@ package setup
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"text/template"
 
@@ -65,14 +64,14 @@ type stage2Vars struct {
 
 // Stage2Input represents an input DTO of the stage2.
 type Stage2Input struct {
-	IssuerURL      string
-	ClientID       string
-	ClientSecret   string
-	ExtraScopes    []string // optional
-	CACertFilename string   // If set, use the CA cert
-	SkipTLSVerify  bool
-	ListenPortArgs []int // non-nil if set by the command arg
-	GrantOptionSet authentication.GrantOptionSet
+	IssuerURL         string
+	ClientID          string
+	ClientSecret      string
+	ExtraScopes       []string // optional
+	CACertFilename    string   // If set, use the CA cert
+	SkipTLSVerify     bool
+	ListenAddressArgs []string // non-nil if set by the command arg
+	GrantOptionSet    authentication.GrantOptionSet
 }
 
 func (u *Setup) DoStage2(ctx context.Context, in Stage2Input) error {
@@ -136,9 +135,7 @@ func makeCredentialPluginArgs(in Stage2Input) []string {
 			args = append(args, "--skip-open-browser")
 		}
 	}
-	for _, port := range in.ListenPortArgs {
-		args = append(args, fmt.Sprintf("--listen-port=%d", port))
-	}
+	args = append(args, in.ListenAddressArgs...)
 	if in.GrantOptionSet.ROPCOption != nil {
 		if in.GrantOptionSet.ROPCOption.Username != "" {
 			args = append(args, "--username="+in.GrantOptionSet.ROPCOption.Username)


### PR DESCRIPTION
This will add `--listen-address` option to bind all interfaces. It is required to run in a container. See #206 for the background.