### PR TITLE
Improve error message if cannot open browser

### DIFF
--- a/pkg/adaptors/browser/browser.go
+++ b/pkg/adaptors/browser/browser.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/google/wire"
 	"github.com/pkg/browser"
-	"golang.org/x/xerrors"
 )
 
 //go:generate mockgen -destination mock_browser/mock_browser.go github.com/int128/kubelogin/pkg/adaptors/browser Interface
@@ -31,8 +30,5 @@ type Browser struct{}
 
 // Open opens the default browser.
 func (*Browser) Open(url string) error {
-	if err := browser.OpenURL(url); err != nil {
-		return xerrors.Errorf("could not open the browser: %w", err)
-	}
-	return nil
+	return browser.OpenURL(url)
 }

--- a/pkg/usecases/authentication/authcode.go
+++ b/pkg/usecases/authentication/authcode.go
@@ -46,12 +46,15 @@ func (u *AuthCode) Do(ctx context.Context, o *AuthCodeOption, client oidcclient.
 			if !ok {
 				return nil
 			}
-			u.Logger.Printf("Open %s for authentication", url)
 			if o.SkipOpenBrowser {
+				u.Logger.Printf("Please visit the following URL in your browser: %s", url)
 				return nil
 			}
 			if err := u.Browser.Open(url); err != nil {
-				u.Logger.V(1).Infof("could not open the browser: %s", err)
+				u.Logger.Printf(`error: could not open the browser: %s
+
+Please visit the following URL in your browser manually: %s`, err, url)
+				return nil
 			}
 			return nil
 		case <-ctx.Done():


### PR DESCRIPTION
This will fix #225.

On Linux:

```
error: could not open the browser: exec: "xdg-open": executable file not found in $PATH

Please visit the following URL in your browser manually: http://localhost:8000
```