### PR TITLE
Update brew template to include support for LinuxBrew

### DIFF
--- a/dist/kubelogin.rb
+++ b/dist/kubelogin.rb
@@ -1,15 +1,27 @@
 class Kubelogin < Formula
   desc "A kubectl plugin for Kubernetes OpenID Connect authentication"
   homepage "https://github.com/int128/kubelogin"
-  url "https://github.com/int128/kubelogin/releases/download/{{ env "VERSION" }}/kubelogin_darwin_amd64.zip"
+  baseurl = "https://github.com/int128/kubelogin/releases/download"
   version "{{ env "VERSION" }}"
-  sha256 "{{ sha256 .darwin_amd64_archive }}"
+  
+  if OS.mac?
+    kernel = "darwin"
+    sha256 "{{ sha256 .darwin_amd64_archive }}"
+  elsif OS.linux?
+    kernel = "linux"
+    sha256 "{{ sha256 .linux_amd64_archive }}"
+  end 
+   
+  url baseurl + "/#{version}/kubelogin_#{kernel}_amd64.zip"
+    
   def install
     bin.install "kubelogin" => "kubelogin"
     ln_s bin/"kubelogin", bin/"kubectl-oidc_login"
   end
+  
   test do
     system "#{bin}/kubelogin -h"
     system "#{bin}/kubectl-oidc_login -h"
   end
+    
 end


### PR DESCRIPTION
This commit introduces an OS check, and extra variables `baseurl` and `kernel` to determine the right archive to download based on the platform. `baseurl` is used to compose the full URI with `#{version}` and `#{kernel}` ruby variables