### PR TITLE
Bump kind version to v0.8.1

### DIFF
--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -19,7 +19,7 @@ jobs:
             go-
       # https://kind.sigs.k8s.io/docs/user/quick-start/
       - run: |
-          wget -q -O ./kind "https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-linux-amd64"
+          wget -q -O ./kind "https://github.com/kubernetes-sigs/kind/releases/download/v0.8.1/kind-linux-amd64"
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
           kind version

--- a/acceptance_test/Makefile
+++ b/acceptance_test/Makefile
@@ -57,7 +57,7 @@ $(OUTPUT_DIR)/bin/chromelogin: chromelogin/main.go
 # create a Dex server
 .PHONY: dex
 dex: $(OUTPUT_DIR)/server.crt $(OUTPUT_DIR)/server.key
-	docker create --name dex-server -p 10443:10443 quay.io/dexidp/dex:v2.21.0 serve /dex.yaml
+	docker create --name dex-server -p 10443:10443 --network kind quay.io/dexidp/dex:v2.21.0 serve /dex.yaml
 	docker cp $(OUTPUT_DIR)/server.crt dex-server:/
 	docker cp $(OUTPUT_DIR)/server.key dex-server:/
 	docker cp dex.yaml dex-server:/


### PR DESCRIPTION
This will upgrade kind to v0.8.1. The new version of kind creates a cluster on `kind` network (instead of `default`) and this PR contains the fix for it.