### PR TITLE
Move to CircleCI macOS build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,25 +1,17 @@
-version: 2
+version: 2.1
+
 jobs:
-  build:
+  test:
     docker:
-      - image: cimg/go:1.14
+      - image: cimg/go:1.14.4
     steps:
-      - run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.24.0
+      - run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.24.0
       - checkout
       - restore_cache:
           keys:
             - go-sum-{{ checksum "go.sum" }}
-      - run:
-          command: go get -v github.com/int128/goxzst github.com/int128/ghcp
-          working_directory: .circleci
       - run: make check
       - run: bash <(curl -s https://codecov.io/bash)
-      - run: make dist
-      - run: |
-          if [ "$CIRCLE_TAG" ]; then
-            make release
-          fi
       - save_cache:
           key: go-sum-{{ checksum "go.sum" }}
           paths:
@@ -27,12 +19,42 @@ jobs:
       - store_artifacts:
           path: gotest.log
 
+  crossbuild:
+    macos:
+      xcode: 11.5.0
+    steps:
+      - run: |
+          curl -sSfL https://dl.google.com/go/go1.14.4.darwin-amd64.tar.gz | tar -C /tmp -xz
+          echo 'export PATH="$PATH:/tmp/go/bin:$HOME/go/bin"' >> $BASH_ENV
+      - checkout
+      - restore_cache:
+          keys:
+            - go-macos-{{ checksum "go.sum" }}
+      - run:
+          command: go get -v github.com/int128/goxzst github.com/int128/ghcp
+          working_directory: .circleci
+      - run: make dist
+      - run: |
+          if [ "$CIRCLE_TAG" ]; then
+            make release
+          fi
+      - save_cache:
+          key: go-macos-{{ checksum "go.sum" }}
+          paths:
+            - ~/go/pkg
+
 workflows:
   version: 2
-  all:
+  build:
     jobs:
-      - build:
+      - test:
+          filters:
+            tags:
+              only: /.*/
+      - crossbuild:
           context: open-source
+          requires:
+            - test
           filters:
             tags:
               only: /.*/

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,6 @@ TARGET_OSARCH := linux_amd64 darwin_amd64 windows_amd64 linux_arm linux_arm64
 VERSION ?= $(CIRCLE_TAG)
 LDFLAGS := -X main.version=$(VERSION)
 
-CGO_ENABLED ?= 0
-export CGO_ENABLED
-
 all: $(TARGET)
 
 $(TARGET): $(wildcard **/*.go)
@@ -19,7 +16,7 @@ $(TARGET): $(wildcard **/*.go)
 .PHONY: check
 check:
 	golangci-lint run
-	CGO_ENABLED=1 go test -v -race -cover -coverprofile=coverage.out ./... > gotest.log
+	go test -v -race -cover -coverprofile=coverage.out ./... > gotest.log
 
 .PHONY: dist
 dist: dist/output


### PR DESCRIPTION
This will introduce CircleCI macOS executor to enable `CGO_ENABLED=1` for macOS build. It will fix #281 and #249. It does not break #198 because implicitly `CGO_ENABLED=0` is set for other platforms.