### PR TITLE
Custom HTML on successful login page

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Flags:
       --oidc-auth-request-extra-params stringToString   Extra query parameters to send with an authentication request (default [])
       --username string                                 If set, perform the resource owner password credentials grant
       --password string                                 If set, use the password instead of asking it
+      --server-success-html string                      Response HTML body on authorization completed
   -h, --help                                            help for get-token
 
 Global Flags:
@@ -198,6 +199,12 @@ You can add extra parameters to the authentication request.
 
 ```yaml
       - --oidc-auth-request-extra-params=ttl=86400
+```
+
+You can add custom HTML to display upon successful authentication.
+
+```yaml
+      - --server-success-html='<p>Kubernetes login successful.  You can now close this page.</p>'
 ```
 
 #### Authorization code flow with keyboard interactive

--- a/pkg/adaptors/cmd/root.go
+++ b/pkg/adaptors/cmd/root.go
@@ -87,7 +87,7 @@ func (o *authenticationOptions) register(f *pflag.FlagSet) {
 	f.StringToStringVar(&o.AuthRequestExtraParams, "oidc-auth-request-extra-params", nil, "Extra query parameters to send with an authentication request")
 	f.StringVar(&o.Username, "username", "", "If set, perform the resource owner password credentials grant")
 	f.StringVar(&o.Password, "password", "", "If set, use the password instead of asking it")
-	f.StringVar(&o.LocalServerSuccessHTML, "server-success-html", "", "HTML page to display upon successful login")
+	f.StringVar(&o.LocalServerSuccessHTML, "server-success-html", "", "Response HTML body on authorization completed")
 }
 
 func (o *authenticationOptions) grantOptionSet() (s authentication.GrantOptionSet, err error) {

--- a/pkg/adaptors/cmd/root.go
+++ b/pkg/adaptors/cmd/root.go
@@ -52,6 +52,7 @@ type authenticationOptions struct {
 	AuthRequestExtraParams map[string]string
 	Username               string
 	Password               string
+	LocalServerSuccessHTML string
 }
 
 // determineListenAddress returns the addresses from the flags.
@@ -86,6 +87,7 @@ func (o *authenticationOptions) register(f *pflag.FlagSet) {
 	f.StringToStringVar(&o.AuthRequestExtraParams, "oidc-auth-request-extra-params", nil, "Extra query parameters to send with an authentication request")
 	f.StringVar(&o.Username, "username", "", "If set, perform the resource owner password credentials grant")
 	f.StringVar(&o.Password, "password", "", "If set, use the password instead of asking it")
+	f.StringVar(&o.LocalServerSuccessHTML, "server-success-html", "", "HTML page to display upon successful login")
 }
 
 func (o *authenticationOptions) grantOptionSet() (s authentication.GrantOptionSet, err error) {
@@ -96,6 +98,7 @@ func (o *authenticationOptions) grantOptionSet() (s authentication.GrantOptionSe
 			SkipOpenBrowser:        o.SkipOpenBrowser,
 			RedirectURLHostname:    o.RedirectURLHostname,
 			AuthRequestExtraParams: o.AuthRequestExtraParams,
+			LocalServerSuccessHTML: o.LocalServerSuccessHTML,
 		}
 	case o.GrantType == "authcode-keyboard":
 		s.AuthCodeKeyboardOption = &authentication.AuthCodeKeyboardOption{

--- a/pkg/adaptors/oidcclient/oidcclient.go
+++ b/pkg/adaptors/oidcclient/oidcclient.go
@@ -48,6 +48,7 @@ type GetTokenByAuthCodeInput struct {
 	PKCEParams             pkce.Params
 	RedirectURLHostname    string
 	AuthRequestExtraParams map[string]string
+	LocalServerSuccessHTML string
 }
 
 // TokenSet represents an output DTO of
@@ -85,6 +86,7 @@ func (c *client) GetTokenByAuthCode(ctx context.Context, in GetTokenByAuthCodeIn
 		LocalServerBindAddress: in.BindAddress,
 		LocalServerReadyChan:   localServerReadyChan,
 		RedirectURLHostname:    in.RedirectURLHostname,
+		LocalServerSuccessHTML: in.LocalServerSuccessHTML,
 	}
 	token, err := oauth2cli.GetToken(ctx, config)
 	if err != nil {

--- a/pkg/usecases/authentication/authcode.go
+++ b/pkg/usecases/authentication/authcode.go
@@ -39,6 +39,7 @@ func (u *AuthCode) Do(ctx context.Context, o *AuthCodeOption, client oidcclient.
 		PKCEParams:             p,
 		RedirectURLHostname:    o.RedirectURLHostname,
 		AuthRequestExtraParams: o.AuthRequestExtraParams,
+		LocalServerSuccessHTML: o.LocalServerSuccessHTML,
 	}
 	readyChan := make(chan string, 1)
 	defer close(readyChan)

--- a/pkg/usecases/authentication/authentication.go
+++ b/pkg/usecases/authentication/authentication.go
@@ -51,6 +51,7 @@ type AuthCodeOption struct {
 	BindAddress            []string
 	RedirectURLHostname    string
 	AuthRequestExtraParams map[string]string
+	LocalServerSuccessHTML string
 }
 
 type AuthCodeKeyboardOption struct {


### PR DESCRIPTION
Adding a CLI option for adding a custom HTML string for the successful login page.  I saw you already had this option in the oauth2cli package so I brought in through to kubelogin.  

Fixes #307 