### PR TITLE
docs: add offline_access scope examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ users:
       - --oidc-issuer-url=ISSUER_URL
       - --oidc-client-id=YOUR_CLIENT_ID
       - --oidc-client-secret=YOUR_CLIENT_SECRET
+      - --oidc-extra-scope=offline_access
 ```
 
 See [setup guide](docs/setup.md) for more.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -138,7 +138,8 @@ Run the following command:
 kubectl oidc-login setup \
   --oidc-issuer-url=ISSUER_URL \
   --oidc-client-id=YOUR_CLIENT_ID \
-  --oidc-client-secret=YOUR_CLIENT_SECRET
+  --oidc-client-secret=YOUR_CLIENT_SECRET \
+  --oidc-extra-scope=offline_access
 ```
 
 It launches the browser and navigates to `http://localhost:8000`.
@@ -205,7 +206,8 @@ kubectl config set-credentials oidc \
   --exec-arg=get-token \
   --exec-arg=--oidc-issuer-url=ISSUER_URL \
   --exec-arg=--oidc-client-id=YOUR_CLIENT_ID \
-  --exec-arg=--oidc-client-secret=YOUR_CLIENT_SECRET
+  --exec-arg=--oidc-client-secret=YOUR_CLIENT_SECRET \
+  --exec-arg=--oidc-extra-scope=offline_access
 ```
 
 


### PR DESCRIPTION
## Description

Most tools that I've used in the pass add the `offline_access` scope by default to the get a `refresh_token` from the `/token` endpoint. Kubelogin does support the `refresh_token` and it took me a bit of debugging to find out the scope was missing and the refresh flow was not working.

I think adding it to the example would be a good way to remind people to specify it, without changing the current behaviour.