### PR TITLE
Add TLS renegotiation flags

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,9 +12,11 @@ Flags:
       --oidc-client-secret string                       Client secret of the provider
       --oidc-extra-scope strings                        Scopes to request to the provider
       --token-cache-dir string                          Path to a directory for token cache (default "~/.kube/cache/oidc-login")
-      --certificate-authority string                    Path to a cert file for the certificate authority
-      --certificate-authority-data string               Base64 encoded cert for the certificate authority
+      --certificate-authority stringArray               Path to a cert file for the certificate authority
+      --certificate-authority-data stringArray          Base64 encoded cert for the certificate authority
       --insecure-skip-tls-verify                        If set, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --tls-renegotiation-once                          If set, allow a remote server to request renegotiation once per connection
+      --tls-renegotiation-freely                        If set, allow a remote server to repeatedly request renegotiation
       --grant-type string                               Authorization grant type to use. One of (auto|authcode|authcode-keyboard|password) (default "auto")
       --listen-address strings                          [authcode] Address to bind to the local server. If multiple addresses are set, it will try binding in order (default [127.0.0.1:8000,127.0.0.1:18000])
       --skip-open-browser                               [authcode] Do not open the browser automatically

--- a/pkg/adaptors/cmd/tls.go
+++ b/pkg/adaptors/cmd/tls.go
@@ -1,26 +1,43 @@
 package cmd
 
 import (
+	"crypto/tls"
+
 	"github.com/int128/kubelogin/pkg/tlsclientconfig"
 	"github.com/spf13/pflag"
 )
 
 type tlsOptions struct {
-	CACertFilename []string
-	CACertData     []string
-	SkipTLSVerify  bool
+	CACertFilename            []string
+	CACertData                []string
+	SkipTLSVerify             bool
+	RenegotiateOnceAsClient   bool
+	RenegotiateFreelyAsClient bool
 }
 
 func (o *tlsOptions) addFlags(f *pflag.FlagSet) {
 	f.StringArrayVar(&o.CACertFilename, "certificate-authority", nil, "Path to a cert file for the certificate authority")
 	f.StringArrayVar(&o.CACertData, "certificate-authority-data", nil, "Base64 encoded cert for the certificate authority")
 	f.BoolVar(&o.SkipTLSVerify, "insecure-skip-tls-verify", false, "If set, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure")
+	f.BoolVar(&o.RenegotiateOnceAsClient, "tls-renegotiation-once", false, "If set, allow a remote server to request renegotiation once per connection")
+	f.BoolVar(&o.RenegotiateFreelyAsClient, "tls-renegotiation-freely", false, "If set, allow a remote server to repeatedly request renegotiation")
 }
 
-func (o *tlsOptions) tlsClientConfig() tlsclientconfig.Config {
+func (o tlsOptions) tlsClientConfig() tlsclientconfig.Config {
 	return tlsclientconfig.Config{
 		CACertFilename: o.CACertFilename,
 		CACertData:     o.CACertData,
 		SkipTLSVerify:  o.SkipTLSVerify,
+		Renegotiation:  o.renegotiationSupport(),
 	}
+}
+
+func (o tlsOptions) renegotiationSupport() tls.RenegotiationSupport {
+	if o.RenegotiateOnceAsClient {
+		return tls.RenegotiateOnceAsClient
+	}
+	if o.RenegotiateFreelyAsClient {
+		return tls.RenegotiateFreelyAsClient
+	}
+	return tls.RenegotiateNever
 }

--- a/pkg/adaptors/cmd/tls_test.go
+++ b/pkg/adaptors/cmd/tls_test.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/int128/kubelogin/pkg/tlsclientconfig"
+	"github.com/spf13/pflag"
+)
+
+func Test_tlsOptions_tlsClientConfig(t *testing.T) {
+	tests := map[string]struct {
+		args []string
+		want tlsclientconfig.Config
+	}{
+		"NoFlag": {},
+		"SkipTLSVerify": {
+			args: []string{
+				"--insecure-skip-tls-verify",
+			},
+			want: tlsclientconfig.Config{
+				SkipTLSVerify: true,
+			},
+		},
+		"CACertFilename1": {
+			args: []string{
+				"--certificate-authority", "/path/to/cert1",
+			},
+			want: tlsclientconfig.Config{
+				CACertFilename: []string{"/path/to/cert1"},
+			},
+		},
+		"CACertFilename2": {
+			args: []string{
+				"--certificate-authority", "/path/to/cert1",
+				"--certificate-authority", "/path/to/cert2",
+			},
+			want: tlsclientconfig.Config{
+				CACertFilename: []string{"/path/to/cert1", "/path/to/cert2"},
+			},
+		},
+		"CACertData1": {
+			args: []string{
+				"--certificate-authority-data", "base64encoded1",
+			},
+			want: tlsclientconfig.Config{
+				CACertData: []string{"base64encoded1"},
+			},
+		},
+		"CACertData2": {
+			args: []string{
+				"--certificate-authority-data", "base64encoded1",
+				"--certificate-authority-data", "base64encoded2",
+			},
+			want: tlsclientconfig.Config{
+				CACertData: []string{"base64encoded1", "base64encoded2"},
+			},
+		},
+		"RenegotiateOnceAsClient": {
+			args: []string{
+				"--tls-renegotiation-once",
+			},
+			want: tlsclientconfig.Config{
+				Renegotiation: tls.RenegotiateOnceAsClient,
+			},
+		},
+		"RenegotiateFreelyAsClient": {
+			args: []string{
+				"--tls-renegotiation-freely",
+			},
+			want: tlsclientconfig.Config{
+				Renegotiation: tls.RenegotiateFreelyAsClient,
+			},
+		},
+	}
+
+	for name, c := range tests {
+		t.Run(name, func(t *testing.T) {
+			var o tlsOptions
+			f := pflag.NewFlagSet("", pflag.ContinueOnError)
+			o.addFlags(f)
+			if err := f.Parse(c.args); err != nil {
+				t.Fatalf("Parse error: %s", err)
+			}
+			got := o.tlsClientConfig()
+			if diff := cmp.Diff(c.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/tlsclientconfig/config.go
+++ b/pkg/tlsclientconfig/config.go
@@ -1,8 +1,11 @@
 package tlsclientconfig
 
+import "crypto/tls"
+
 // Config represents a config for TLS client.
 type Config struct {
 	CACertFilename []string
 	CACertData     []string
 	SkipTLSVerify  bool
+	Renegotiation  tls.RenegotiationSupport
 }

--- a/pkg/tlsclientconfig/loader/load.go
+++ b/pkg/tlsclientconfig/loader/load.go
@@ -40,6 +40,7 @@ func (l *Loader) Load(config tlsclientconfig.Config) (*tls.Config, error) {
 	return &tls.Config{
 		RootCAs:            rootCAs,
 		InsecureSkipVerify: config.SkipTLSVerify,
+		Renegotiation:      config.Renegotiation,
 	}, nil
 }
 


### PR DESCRIPTION
This will add flags for TLS renegotiation config. This will fix https://github.com/int128/kubelogin/issues/408 and https://github.com/int128/kubelogin/pull/401.