### PR TITLE
Fix TLS error if CA certificate is not set

### DIFF
--- a/pkg/tlsclientconfig/loader/load.go
+++ b/pkg/tlsclientconfig/loader/load.go
@@ -37,6 +37,10 @@ func (l *Loader) Load(config tlsclientconfig.Config) (*tls.Config, error) {
 			return nil, xerrors.Errorf("could not load the certificate: %w", err)
 		}
 	}
+	if len(rootCAs.Subjects()) == 0 {
+		// use the host's root CA set
+		rootCAs = nil
+	}
 	return &tls.Config{
 		RootCAs:            rootCAs,
 		InsecureSkipVerify: config.SkipTLSVerify,

--- a/pkg/tlsclientconfig/loader/load_test.go
+++ b/pkg/tlsclientconfig/loader/load_test.go
@@ -9,6 +9,15 @@ import (
 
 func TestLoader_Load(t *testing.T) {
 	var loader Loader
+	t.Run("Zero", func(t *testing.T) {
+		cfg, err := loader.Load(tlsclientconfig.Config{})
+		if err != nil {
+			t.Errorf("Load error: %s", err)
+		}
+		if cfg.RootCAs != nil {
+			t.Errorf("RootCAs wants nil but was %+v", cfg.RootCAs)
+		}
+	})
 	t.Run("ValidFile", func(t *testing.T) {
 		cfg, err := loader.Load(tlsclientconfig.Config{
 			CACertFilename: []string{"testdata/ca1.crt"},


### PR DESCRIPTION
This will fix the following error:

```console
% ./kubelogin get-token --oidc-issuer-url=https://accounts.google.com --oidc-client-id REDACTED --oidc-client-secret REDACTED
error: get-token: authentication error: oidc error: oidc discovery error: Get "https://accounts.google.com/.well-known/openid-configuration": x509: certificate signed by unknown authority
```

Fix up #409.