### PR TITLE
Include all options to token cache key

### DIFF
--- a/pkg/adaptors/tokencache/tokencache_test.go
+++ b/pkg/adaptors/tokencache/tokencache_test.go
@@ -7,6 +7,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/int128/kubelogin/pkg/oidc"
+	"github.com/int128/kubelogin/pkg/tlsclientconfig"
+	"github.com/int128/kubelogin/pkg/usecases/authentication"
+	"github.com/int128/kubelogin/pkg/usecases/authentication/ropc"
 )
 
 func TestRepository_FindByKey(t *testing.T) {
@@ -15,12 +18,19 @@ func TestRepository_FindByKey(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		dir := t.TempDir()
 		key := Key{
-			IssuerURL:      "YOUR_ISSUER",
-			ClientID:       "YOUR_CLIENT_ID",
-			ClientSecret:   "YOUR_CLIENT_SECRET",
-			ExtraScopes:    []string{"openid", "email"},
-			CACertFilename: "/path/to/cert",
-			SkipTLSVerify:  false,
+			Provider: oidc.Provider{
+				IssuerURL:    "YOUR_ISSUER",
+				ClientID:     "YOUR_CLIENT_ID",
+				ClientSecret: "YOUR_CLIENT_SECRET",
+			},
+			GrantOptionSet: authentication.GrantOptionSet{
+				ROPCOption: &ropc.Option{
+					Username: "YOUR_USERNAME",
+				},
+			},
+			TLSClientConfig: tlsclientconfig.Config{
+				CACertData: []string{"BASE64ENCODED"},
+			},
 		}
 		json := `{"id_token":"YOUR_ID_TOKEN","refresh_token":"YOUR_REFRESH_TOKEN"}`
 		filename, err := computeFilename(key)
@@ -49,12 +59,19 @@ func TestRepository_Save(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		dir := t.TempDir()
 		key := Key{
-			IssuerURL:      "YOUR_ISSUER",
-			ClientID:       "YOUR_CLIENT_ID",
-			ClientSecret:   "YOUR_CLIENT_SECRET",
-			ExtraScopes:    []string{"openid", "email"},
-			CACertFilename: "/path/to/cert",
-			SkipTLSVerify:  false,
+			Provider: oidc.Provider{
+				IssuerURL:    "YOUR_ISSUER",
+				ClientID:     "YOUR_CLIENT_ID",
+				ClientSecret: "YOUR_CLIENT_SECRET",
+			},
+			GrantOptionSet: authentication.GrantOptionSet{
+				ROPCOption: &ropc.Option{
+					Username: "YOUR_USERNAME",
+				},
+			},
+			TLSClientConfig: tlsclientconfig.Config{
+				CACertData: []string{"BASE64ENCODED"},
+			},
 		}
 		tokenSet := oidc.TokenSet{IDToken: "YOUR_ID_TOKEN", RefreshToken: "YOUR_REFRESH_TOKEN"}
 		if err := r.Save(dir, key, tokenSet); err != nil {

--- a/pkg/oidc/oidc.go
+++ b/pkg/oidc/oidc.go
@@ -11,10 +11,11 @@ import (
 
 // Provider represents an OIDC provider.
 type Provider struct {
-	IssuerURL    string
-	ClientID     string
-	ClientSecret string   // optional
-	ExtraScopes  []string // optional
+	// require omitempty for tokencache.Key
+	IssuerURL    string   `json:",omitempty"`
+	ClientID     string   `json:",omitempty"`
+	ClientSecret string   `json:",omitempty"` // optional
+	ExtraScopes  []string `json:",omitempty"` // optional
 }
 
 // TokenSet represents a set of ID token and refresh token.

--- a/pkg/tlsclientconfig/config.go
+++ b/pkg/tlsclientconfig/config.go
@@ -4,8 +4,9 @@ import "crypto/tls"
 
 // Config represents a config for TLS client.
 type Config struct {
-	CACertFilename []string
-	CACertData     []string
-	SkipTLSVerify  bool
-	Renegotiation  tls.RenegotiationSupport
+	// require omitempty for tokencache.Key
+	CACertFilename []string                 `json:",omitempty"`
+	CACertData     []string                 `json:",omitempty"`
+	SkipTLSVerify  bool                     `json:",omitempty"`
+	Renegotiation  tls.RenegotiationSupport `json:",omitempty"`
 }

--- a/pkg/usecases/authentication/authcode/browser.go
+++ b/pkg/usecases/authentication/authcode/browser.go
@@ -14,14 +14,15 @@ import (
 )
 
 type BrowserOption struct {
-	SkipOpenBrowser            bool
-	BindAddress                []string
-	AuthenticationTimeout      time.Duration
-	OpenURLAfterAuthentication string
-	RedirectURLHostname        string
-	AuthRequestExtraParams     map[string]string
-	LocalServerCertFile        string
-	LocalServerKeyFile         string
+	// require omitempty for tokencache.Key
+	SkipOpenBrowser            bool              `json:",omitempty"`
+	BindAddress                []string          `json:",omitempty"`
+	AuthenticationTimeout      time.Duration     `json:",omitempty"`
+	OpenURLAfterAuthentication string            `json:",omitempty"`
+	RedirectURLHostname        string            `json:",omitempty"`
+	AuthRequestExtraParams     map[string]string `json:",omitempty"`
+	LocalServerCertFile        string            `json:",omitempty"`
+	LocalServerKeyFile         string            `json:",omitempty"`
 }
 
 // Browser provides the authentication code flow using the browser.

--- a/pkg/usecases/authentication/authcode/keyboard.go
+++ b/pkg/usecases/authentication/authcode/keyboard.go
@@ -15,7 +15,8 @@ const keyboardPrompt = "Enter code: "
 const oobRedirectURI = "urn:ietf:wg:oauth:2.0:oob"
 
 type KeyboardOption struct {
-	AuthRequestExtraParams map[string]string
+	// require omitempty for tokencache.Key
+	AuthRequestExtraParams map[string]string `json:",omitempty"`
 }
 
 // Keyboard provides the authorization code flow with keyboard interactive.

--- a/pkg/usecases/authentication/authentication.go
+++ b/pkg/usecases/authentication/authentication.go
@@ -38,9 +38,10 @@ type Input struct {
 }
 
 type GrantOptionSet struct {
-	AuthCodeBrowserOption  *authcode.BrowserOption
-	AuthCodeKeyboardOption *authcode.KeyboardOption
-	ROPCOption             *ropc.Option
+	// require omitempty for tokencache.Key
+	AuthCodeBrowserOption  *authcode.BrowserOption  `json:",omitempty"`
+	AuthCodeKeyboardOption *authcode.KeyboardOption `json:",omitempty"`
+	ROPCOption             *ropc.Option             `json:",omitempty"`
 }
 
 // Output represents an output DTO of the Authentication use-case.

--- a/pkg/usecases/authentication/ropc/ropc.go
+++ b/pkg/usecases/authentication/ropc/ropc.go
@@ -14,8 +14,9 @@ const usernamePrompt = "Username: "
 const passwordPrompt = "Password: "
 
 type Option struct {
-	Username string
-	Password string // If empty, read a password using Reader.ReadPassword()
+	// require omitempty for tokencache.Key
+	Username string `json:",omitempty"`
+	Password string `json:",omitempty"` // If empty, read a password using Reader.ReadPassword()
 }
 
 // ROPC provides the resource owner password credentials flow.


### PR DESCRIPTION
This will include all possible options to the token cache key. This will expand the original implementation #404 to all options.