### PR TITLE
Change mutex scope to bind address port

### DIFF
--- a/pkg/usecases/credentialplugin/get_token.go
+++ b/pkg/usecases/credentialplugin/get_token.go
@@ -6,19 +6,20 @@ package credentialplugin
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 
-	"github.com/int128/kubelogin/pkg/credentialplugin"
-	"github.com/int128/kubelogin/pkg/infrastructure/mutex"
-	"github.com/int128/kubelogin/pkg/tokencache/repository"
-
 	"github.com/google/wire"
+	"github.com/int128/kubelogin/pkg/credentialplugin"
 	"github.com/int128/kubelogin/pkg/credentialplugin/writer"
 	"github.com/int128/kubelogin/pkg/infrastructure/logger"
+	"github.com/int128/kubelogin/pkg/infrastructure/mutex"
 	"github.com/int128/kubelogin/pkg/oidc"
 	"github.com/int128/kubelogin/pkg/tlsclientconfig"
 	"github.com/int128/kubelogin/pkg/tokencache"
+	"github.com/int128/kubelogin/pkg/tokencache/repository"
 	"github.com/int128/kubelogin/pkg/usecases/authentication"
+	"github.com/int128/kubelogin/pkg/usecases/authentication/authcode"
 )
 
 //go:generate mockgen -destination mock_credentialplugin/mock_credentialplugin.go github.com/int128/kubelogin/pkg/usecases/credentialplugin Interface
@@ -51,14 +52,22 @@ type GetToken struct {
 func (u *GetToken) Do(ctx context.Context, in Input) error {
 	u.Logger.V(1).Infof("WARNING: log may contain your secrets such as token or password")
 
-	// Prevent multiple concurrent token query using a file mutex. See https://github.com/int128/kubelogin/issues/389
-	lock, err := u.Mutex.Acquire(ctx, "get-token")
-	if err != nil {
-		return err
+	// Prevent multiple concurrent port binding using a file mutex.
+	// See https://github.com/int128/kubelogin/issues/389
+	bindPorts := extractBindAddressPorts(in.GrantOptionSet.AuthCodeBrowserOption)
+	if bindPorts != nil {
+		key := fmt.Sprintf("get-token-%s", strings.Join(bindPorts, "-"))
+		u.Logger.V(1).Infof("acquiring a lock %s", key)
+		lock, err := u.Mutex.Acquire(ctx, key)
+		if err != nil {
+			return fmt.Errorf("could not acquire a lock: %w", err)
+		}
+		defer func() {
+			if err := u.Mutex.Release(lock); err != nil {
+				u.Logger.V(1).Infof("could not release the lock: %s", err)
+			}
+		}()
 	}
-	defer func() {
-		_ = u.Mutex.Release(lock)
-	}()
 
 	u.Logger.V(1).Infof("finding a token from cache directory %s", in.TokenCacheDir)
 	tokenCacheKey := tokencache.Key{
@@ -111,4 +120,22 @@ func (u *GetToken) Do(ctx context.Context, in Input) error {
 		return fmt.Errorf("could not write the token to client-go: %w", err)
 	}
 	return nil
+}
+
+func extractBindAddressPorts(o *authcode.BrowserOption) []string {
+	if o == nil {
+		return nil
+	}
+	var ports []string
+	for _, addr := range o.BindAddress {
+		_, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil // invalid address
+		}
+		if port == "0" {
+			return nil // any port
+		}
+		ports = append(ports, port)
+	}
+	return ports
 }


### PR DESCRIPTION
This will change the mutex scope of get-token to the bind port. See https://github.com/int128/kubelogin/issues/421.