### PR TITLE
Fix krew release

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -24,39 +24,39 @@ spec:
     You need to setup the OIDC provider, Kubernetes API server, role binding and kubeconfig.
   version: {{ .TagName }}
   platforms:
-    - bin: kubelogin
-      {{ addURIAndSha "https://github.com/int128/kubelogin/releases/download/{{ .TagName }}/kubelogin_linux_amd64.zip" .TagName }}
-      selector:
-        matchLabels:
-          os: linux
-          arch: amd64
-    - bin: kubelogin
-      {{ addURIAndSha "https://github.com/int128/kubelogin/releases/download/{{ .TagName }}/kubelogin_linux_arm64.zip" .TagName }}
-      selector:
-        matchLabels:
-          os: linux
-          arch: arm64
-    - bin: kubelogin
-      {{ addURIAndSha "https://github.com/int128/kubelogin/releases/download/{{ .TagName }}/kubelogin_linux_arm.zip" .TagName }}
-      selector:
-        matchLabels:
-          os: linux
-          arch: arm
-    - bin: kubelogin
-      {{ addURIAndSha "https://github.com/int128/kubelogin/releases/download/{{ .TagName }}/kubelogin_darwin_amd64.zip" .TagName }}
-      selector:
-        matchLabels:
-          os: darwin
-          arch: amd64
-    - bin: kubelogin
-      {{ addURIAndSha "https://github.com/int128/kubelogin/releases/download/{{ .TagName }}/kubelogin_darwin_arm64.zip" .TagName }}
-      selector:
-        matchLabels:
-          os: darwin
-          arch: arm64
-    - bin: kubelogin
-      {{ addURIAndSha "https://github.com/int128/kubelogin/releases/download/{{ .TagName }}/kubelogin_windows_amd64.zip" .TagName }}
-      selector:
-        matchLabels:
-          os: windows
-          arch: amd64
+  - bin: kubelogin
+    {{ addURIAndSha "https://github.com/int128/kubelogin/releases/download/{{ .TagName }}/kubelogin_linux_amd64.zip" .TagName }}
+    selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+  - bin: kubelogin
+    {{ addURIAndSha "https://github.com/int128/kubelogin/releases/download/{{ .TagName }}/kubelogin_linux_arm64.zip" .TagName }}
+    selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+  - bin: kubelogin
+    {{ addURIAndSha "https://github.com/int128/kubelogin/releases/download/{{ .TagName }}/kubelogin_linux_arm.zip" .TagName }}
+    selector:
+      matchLabels:
+        os: linux
+        arch: arm
+  - bin: kubelogin
+    {{ addURIAndSha "https://github.com/int128/kubelogin/releases/download/{{ .TagName }}/kubelogin_darwin_amd64.zip" .TagName }}
+    selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+  - bin: kubelogin
+    {{ addURIAndSha "https://github.com/int128/kubelogin/releases/download/{{ .TagName }}/kubelogin_darwin_arm64.zip" .TagName }}
+    selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+  - bin: kubelogin
+    {{ addURIAndSha "https://github.com/int128/kubelogin/releases/download/{{ .TagName }}/kubelogin_windows_amd64.zip" .TagName }}
+    selector:
+      matchLabels:
+        os: windows
+        arch: amd64

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -25,37 +25,37 @@ spec:
   version: {{ .TagName }}
   platforms:
     - bin: kubelogin
-      {{ addURIAndSha "https://github.com/int128/kubelogin/releases/download/{{ TagName }}/kubelogin_linux_amd64.zip" .TagName }}
+      {{ addURIAndSha "https://github.com/int128/kubelogin/releases/download/{{ .TagName }}/kubelogin_linux_amd64.zip" .TagName }}
       selector:
         matchLabels:
           os: linux
           arch: amd64
     - bin: kubelogin
-      {{ addURIAndSha "https://github.com/int128/kubelogin/releases/download/{{ TagName }}/kubelogin_linux_arm64.zip" .TagName }}
+      {{ addURIAndSha "https://github.com/int128/kubelogin/releases/download/{{ .TagName }}/kubelogin_linux_arm64.zip" .TagName }}
       selector:
         matchLabels:
           os: linux
           arch: arm64
     - bin: kubelogin
-      {{ addURIAndSha "https://github.com/int128/kubelogin/releases/download/{{ TagName }}/kubelogin_linux_arm.zip" .TagName }}
+      {{ addURIAndSha "https://github.com/int128/kubelogin/releases/download/{{ .TagName }}/kubelogin_linux_arm.zip" .TagName }}
       selector:
         matchLabels:
           os: linux
           arch: arm
     - bin: kubelogin
-      {{ addURIAndSha "https://github.com/int128/kubelogin/releases/download/{{ TagName }}/kubelogin_darwin_amd64.zip" .TagName }}
+      {{ addURIAndSha "https://github.com/int128/kubelogin/releases/download/{{ .TagName }}/kubelogin_darwin_amd64.zip" .TagName }}
       selector:
         matchLabels:
           os: darwin
           arch: amd64
     - bin: kubelogin
-      {{ addURIAndSha "https://github.com/int128/kubelogin/releases/download/{{ TagName }}/kubelogin_darwin_arm64.zip" .TagName }}
+      {{ addURIAndSha "https://github.com/int128/kubelogin/releases/download/{{ .TagName }}/kubelogin_darwin_arm64.zip" .TagName }}
       selector:
         matchLabels:
           os: darwin
           arch: arm64
     - bin: kubelogin
-      {{ addURIAndSha "https://github.com/int128/kubelogin/releases/download/{{ TagName }}/kubelogin_windows_amd64.zip" .TagName }}
+      {{ addURIAndSha "https://github.com/int128/kubelogin/releases/download/{{ .TagName }}/kubelogin_windows_amd64.zip" .TagName }}
       selector:
         matchLabels:
           os: windows


### PR DESCRIPTION
Fix the publish error https://github.com/int128/kubelogin/runs/2162962445.

```console
time="2021-03-22T04:06:39Z" level=fatal msg="template: .krew.yaml:28:9: executing \".krew.yaml\" at <addURIAndSha \"https://github.com/int128/kubelogin/releases/download/{{ TagName }}/kubelogin_linux_amd64.zip\" .TagName>: error calling addURIAndSha: template: url:1: function \"TagName\" not defined"
```