### PR TITLE
refactor: add --oidc-use-pkce flag to force PKCE authorization flow

### DIFF
--- a/pkg/cmd/get_token.go
+++ b/pkg/cmd/get_token.go
@@ -17,6 +17,7 @@ type getTokenOptions struct {
 	ClientID              string
 	ClientSecret          string
 	ExtraScopes           []string
+	UsePKCE               bool
 	TokenCacheDir         string
 	tlsOptions            tlsOptions
 	authenticationOptions authenticationOptions
@@ -27,6 +28,7 @@ func (o *getTokenOptions) addFlags(f *pflag.FlagSet) {
 	f.StringVar(&o.ClientID, "oidc-client-id", "", "Client ID of the provider (mandatory)")
 	f.StringVar(&o.ClientSecret, "oidc-client-secret", "", "Client secret of the provider")
 	f.StringSliceVar(&o.ExtraScopes, "oidc-extra-scope", nil, "Scopes to request to the provider")
+	f.BoolVar(&o.UsePKCE, "oidc-use-pkce", false, "Force PKCE usage")
 	f.StringVar(&o.TokenCacheDir, "token-cache-dir", defaultTokenCacheDir, "Path to a directory for token cache")
 	o.tlsOptions.addFlags(f)
 	o.authenticationOptions.addFlags(f)
@@ -74,6 +76,7 @@ func (cmd *GetToken) New() *cobra.Command {
 					IssuerURL:    o.IssuerURL,
 					ClientID:     o.ClientID,
 					ClientSecret: o.ClientSecret,
+					UsePKCE:      o.UsePKCE,
 					ExtraScopes:  o.ExtraScopes,
 				},
 				TokenCacheDir:   o.TokenCacheDir,

--- a/pkg/cmd/setup.go
+++ b/pkg/cmd/setup.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/int128/kubelogin/pkg/usecases/setup"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -13,6 +14,7 @@ type setupOptions struct {
 	ClientID              string
 	ClientSecret          string
 	ExtraScopes           []string
+	UsePKCE               bool
 	tlsOptions            tlsOptions
 	authenticationOptions authenticationOptions
 }
@@ -22,6 +24,7 @@ func (o *setupOptions) addFlags(f *pflag.FlagSet) {
 	f.StringVar(&o.ClientID, "oidc-client-id", "", "Client ID of the provider")
 	f.StringVar(&o.ClientSecret, "oidc-client-secret", "", "Client secret of the provider")
 	f.StringSliceVar(&o.ExtraScopes, "oidc-extra-scope", nil, "Scopes to request to the provider")
+	f.BoolVar(&o.UsePKCE, "oidc-use-pkce", false, "Force PKCE usage")
 	o.tlsOptions.addFlags(f)
 	o.authenticationOptions.addFlags(f)
 }
@@ -46,6 +49,7 @@ func (cmd *Setup) New() *cobra.Command {
 				ClientID:        o.ClientID,
 				ClientSecret:    o.ClientSecret,
 				ExtraScopes:     o.ExtraScopes,
+				UsePKCE:         o.UsePKCE,
 				GrantOptionSet:  grantOptionSet,
 				TLSClientConfig: o.tlsOptions.tlsClientConfig(),
 			}

--- a/pkg/oidc/client/factory.go
+++ b/pkg/oidc/client/factory.go
@@ -12,6 +12,7 @@ import (
 	"github.com/int128/kubelogin/pkg/infrastructure/logger"
 	"github.com/int128/kubelogin/pkg/oidc"
 	"github.com/int128/kubelogin/pkg/oidc/client/logging"
+	"github.com/int128/kubelogin/pkg/pkce"
 	"github.com/int128/kubelogin/pkg/tlsclientconfig"
 	"github.com/int128/kubelogin/pkg/tlsclientconfig/loader"
 	"golang.org/x/oauth2"
@@ -60,6 +61,9 @@ func (f *Factory) New(ctx context.Context, p oidc.Provider, tlsClientConfig tlsc
 	supportedPKCEMethods, err := extractSupportedPKCEMethods(provider)
 	if err != nil {
 		return nil, fmt.Errorf("could not determine supported PKCE methods: %w", err)
+	}
+	if len(supportedPKCEMethods) == 0 && p.UsePKCE {
+		supportedPKCEMethods = []string{pkce.MethodS256}
 	}
 	return &client{
 		httpClient: httpClient,

--- a/pkg/oidc/oidc.go
+++ b/pkg/oidc/oidc.go
@@ -15,6 +15,7 @@ type Provider struct {
 	ClientID     string
 	ClientSecret string   // optional
 	ExtraScopes  []string // optional
+	UsePKCE      bool     // optional
 }
 
 // TokenSet represents a set of ID token and refresh token.

--- a/pkg/pkce/pkce.go
+++ b/pkg/pkce/pkce.go
@@ -14,7 +14,7 @@ var Plain Params
 
 const (
 	// code challenge methods defined as https://tools.ietf.org/html/rfc7636#section-4.3
-	methodS256 = "S256"
+	MethodS256 = "S256"
 )
 
 // Params represents a set of the PKCE parameters.
@@ -33,7 +33,7 @@ func (p Params) IsZero() bool {
 // It returns Plain if no method is available.
 func New(methods []string) (Params, error) {
 	for _, method := range methods {
-		if method == methodS256 {
+		if method == MethodS256 {
 			return NewS256()
 		}
 	}
@@ -63,7 +63,7 @@ func computeS256(b []byte) Params {
 	_, _ = s.Write([]byte(v))
 	return Params{
 		CodeChallenge:       base64URLEncode(s.Sum(nil)),
-		CodeChallengeMethod: methodS256,
+		CodeChallengeMethod: MethodS256,
 		CodeVerifier:        v,
 	}
 }

--- a/pkg/usecases/setup/stage2.go
+++ b/pkg/usecases/setup/stage2.go
@@ -73,6 +73,7 @@ type Stage2Input struct {
 	ClientID          string
 	ClientSecret      string
 	ExtraScopes       []string // optional
+	UsePKCE           bool     // optional
 	ListenAddressArgs []string // non-nil if set by the command arg
 	GrantOptionSet    authentication.GrantOptionSet
 	TLSClientConfig   tlsclientconfig.Config
@@ -86,6 +87,7 @@ func (u *Setup) DoStage2(ctx context.Context, in Stage2Input) error {
 			ClientID:     in.ClientID,
 			ClientSecret: in.ClientSecret,
 			ExtraScopes:  in.ExtraScopes,
+			UsePKCE:      in.UsePKCE,
 		},
 		GrantOptionSet:  in.GrantOptionSet,
 		TLSClientConfig: in.TLSClientConfig,
@@ -122,6 +124,9 @@ func makeCredentialPluginArgs(in Stage2Input) []string {
 	}
 	for _, extraScope := range in.ExtraScopes {
 		args = append(args, "--oidc-extra-scope="+extraScope)
+	}
+	if in.UsePKCE {
+		args = append(args, "--oidc-use-pkce")
 	}
 	for _, f := range in.TLSClientConfig.CACertFilename {
 		args = append(args, "--certificate-authority="+f)


### PR DESCRIPTION
Adds a flag to force PKCE authorization flow. Solve the issue described in #440. 

I had a similar issue when using AWS Cognito, as it doesn't have `code_challenge_methods_supported` in its configuration and the documentation recommends the use! Creating an app without a secret I was able to correctly get a valid token, but I wanted the extra layer of security by using PKCE.