### PR TITLE
Fix authentication error in system-test

### DIFF
--- a/.github/workflows/system-test.yaml
+++ b/.github/workflows/system-test.yaml
@@ -39,4 +39,8 @@ jobs:
       - run: sudo apt install -y libnss3-tools
       - run: mkdir -p ~/.pki/nssdb
       - run: echo '127.0.0.1 dex-server' | sudo tee -a /etc/hosts
+
       - run: make -C system_test -j3
+
+      - run: make -C system_test logs
+        if: always()

--- a/system_test/Makefile
+++ b/system_test/Makefile
@@ -24,6 +24,10 @@ setup-chrome: cert
 cert:
 	$(MAKE) -C cert
 
+.PHONY: logs
+logs:
+	$(MAKE) -C cluster logs
+
 .PHONY: terminate
 terminate:
 	$(MAKE) -C cluster terminate

--- a/system_test/cluster/Makefile
+++ b/system_test/cluster/Makefile
@@ -18,6 +18,10 @@ cluster:
 	kubectl create clusterrole cluster-readonly --verb=get,watch,list --resource='*.*'
 	kubectl create clusterrolebinding cluster-readonly --clusterrole=cluster-readonly --user=admin@example.com
 
+.PHONY: logs
+logs:
+	kubectl -n kube-system logs kube-apiserver-kubelogin-system-test-control-plane
+
 .PHONY: terminate
 terminate:
 	kind delete cluster --name $(CLUSTER_NAME)

--- a/system_test/cluster/cluster.yaml
+++ b/system_test/cluster/cluster.yaml
@@ -1,20 +1,19 @@
+# https://kind.sigs.k8s.io/docs/user/configuration/
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-# https://github.com/dexidp/dex/blob/master/Documentation/kubernetes.md
-kubeadmConfigPatches:
-  - |
-    apiVersion: kubeadm.k8s.io/v1beta2
-    kind: ClusterConfiguration
-    metadata:
-      name: config
-    apiServer:
-      extraArgs:
-        oidc-issuer-url: https://dex-server:10443/dex
-        oidc-client-id: YOUR_CLIENT_ID
-        oidc-username-claim: email
-        oidc-ca-file: /usr/local/share/ca-certificates/dex-ca.crt
 nodes:
   - role: control-plane
+
+    kubeadmConfigPatches:
+      - |
+        kind: ClusterConfiguration
+        apiServer:
+          extraArgs:
+            oidc-issuer-url: https://dex-server:10443/dex
+            oidc-client-id: YOUR_CLIENT_ID
+            oidc-username-claim: email
+            oidc-ca-file: /usr/local/share/ca-certificates/dex-ca.crt
+
     extraMounts:
       - hostPath: /tmp/kubelogin-system-test-dex-ca.crt
         containerPath: /usr/local/share/ca-certificates/dex-ca.crt

--- a/system_test/login/Makefile
+++ b/system_test/login/Makefile
@@ -31,10 +31,6 @@ test: build
 		--exec-arg=--browser-command=$(BIN_DIR)/chromelogin
 	# make sure we can access the cluster
 	kubectl --user=oidc cluster-info
-	# switch the current context
-	kubectl config set-context --current --user=oidc
-	# make sure we can access the cluster
-	kubectl cluster-info
 
 .PHONY: build
 build: $(BIN_DIR)/kubectl-oidc_login $(BIN_DIR)/chromelogin


### PR DESCRIPTION
## Problem to solve
```console
# see the setup instruction
kubectl oidc-login setup \
	--oidc-issuer-url=https://dex-server:10443/dex \
	--oidc-client-id=YOUR_CLIENT_ID \
	--oidc-client-secret=YOUR_CLIENT_SECRET \
	--oidc-extra-scope=email \
	--certificate-authority=../cert/ca.crt \
	--browser-command=/home/runner/work/kubelogin/kubelogin/bin/chromelogin
authentication in progress...
08:30:30.446683 main.go:54: location: https://dex-server:10443/dex/auth/local?req=dfeoyatqf2rz6tt4ipa4vhjjp
08:30:30.502648 main.go:89: location: https://dex-server:10443/dex/auth/local?req=dfeoyatqf2rz6tt4ipa4vhjjp [dex]
08:30:30.979216 main.go:89: location: https://dex-server:10443/dex/approval?req=dfeoyatqf2rz6tt4ipa4vhjjp [dex]
08:30:31.133477 main.go:89: location: http://localhost:8000/?code=abqsvbxq3oyzr44eajcnk3poh&state=aEkzzDvpr8YCznEcfK74BJnQoliUIuBAzqvADdEtAoM [Authenticated]

## 2. Verify authentication

You got a token with the following claims:

{
  "iss": "https://dex-server:10443/dex",
  "sub": "CiQwOGE4Njg0Yi1kYjg4LTRiNzMtOTBhOS0zY2QxNjYxZjU0NjYSBWxvY2Fs",
  "aud": "YOUR_CLIENT_ID",
  "exp": 1651998631,
  "iat": 1651912231,
  "nonce": "3khHllIDlWAnTU3SU_-0GBVh7e8uB88f1NpJkc1hdcU",
  "at_hash": "3VMEnmkrPsAPkcUrh21NYw",
  "email": "admin@example.com",
  "email_verified": true
}

## 3. Bind a cluster role

Run the following command:

	kubectl create clusterrolebinding oidc-cluster-admin --clusterrole=cluster-admin --user='https://dex-server:10443/dex#CiQwOGE4Njg0Yi1kYjg4LTRiNzMtOTBhOS0zY2QxNjYxZjU0NjYSBWxvY2Fs'

## 4. Set up the Kubernetes API server

Add the following options to the kube-apiserver:

	--oidc-issuer-url=https://dex-server:10443/dex
	--oidc-client-id=YOUR_CLIENT_ID

## 5. Set up the kubeconfig

Run the following command:

	kubectl config set-credentials oidc \
	  --exec-api-version=client.authentication.k8s.io/v1beta1 \
	  --exec-command=kubectl \
	  --exec-arg=oidc-login \
	  --exec-arg=get-token \
	  --exec-arg=--oidc-issuer-url=https://dex-server:10443/dex \
	  --exec-arg=--oidc-client-id=YOUR_CLIENT_ID \
	  --exec-arg=--oidc-client-secret=YOUR_CLIENT_SECRET \
	  --exec-arg=--oidc-extra-scope=email \
	  --exec-arg=--certificate-authority=../cert/ca.crt \
	  --exec-arg=--browser-command=/home/runner/work/kubelogin/kubelogin/bin/chromelogin

## 6. Verify cluster access

Make sure you can access the Kubernetes cluster.

	kubectl --user=oidc get nodes

You can switch the default context to oidc.

	kubectl config set-context --current --user=oidc

You can share the kubeconfig to your team members for on-boarding.
# set up the kubeconfig
kubectl config set-credentials oidc \
	--exec-api-version=client.authentication.k8s.io/v1beta1 \
	--exec-command=kubectl \
	--exec-arg=oidc-login \
	--exec-arg=get-token \
	--exec-arg=--oidc-issuer-url=https://dex-server:10443/dex \
	--exec-arg=--oidc-client-id=YOUR_CLIENT_ID \
	--exec-arg=--oidc-client-secret=YOUR_CLIENT_SECRET \
	--exec-arg=--oidc-extra-scope=email \
	--exec-arg=--certificate-authority=../cert/ca.crt \
	--exec-arg=--browser-command=/home/runner/work/kubelogin/kubelogin/bin/chromelogin
User "oidc" set.
# make sure we can access the cluster
kubectl --user=oidc cluster-info
08:30:31.571094 main.go:54: location: https://dex-server:10443/dex/auth/local?req=a4skzc2atscdvn5uymc3ejo6p
08:30:31.587480 main.go:89: location: https://dex-server:10443/dex/auth/local?req=a4skzc2atscdvn5uymc3ejo6p [dex]
08:30:31.871513 main.go:89: location: https://dex-server:10443/dex/approval?req=a4skzc2atscdvn5uymc3ejo6p [dex]
08:30:31.941143 main.go:89: location: http://localhost:8000/?code=cqopifao5dmpn2lcjmukbjed7&state=odjVXVTZHfRCwutamT_FlwuGPuNmSkophGR3VhOGeDg [Authenticated]

error: You must be logged in to the server (Unauthorized)
```

https://github.com/int128/kubelogin/runs/6333312005?check_suite_focus=true

## How to solve
It seems the place of `kubeadmConfigPatches` has been moved.
https://kind.sigs.k8s.io/docs/user/configuration/#kubeadm-config-patches
