### PR TITLE
Use cgo when cross-compiling macos arm64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,6 +40,7 @@ jobs:
           - runs-on: macos-latest
             GOOS: darwin
             GOARCH: arm64
+            CGO_ENABLED: 1 # https://github.com/int128/kubelogin/issues/762
           - runs-on: windows-latest
             GOOS: windows
             GOARCH: amd64


### PR DESCRIPTION
Closes https://github.com/int128/kubelogin/issues/762