### PR TITLE
[BUG] :bug: Send access_token instead of id_token to apiserver

### DIFF
--- a/pkg/oidc/client/client.go
+++ b/pkg/oidc/client/client.go
@@ -208,5 +208,6 @@ func (c *client) verifyToken(ctx context.Context, token *oauth2.Token, nonce str
 	return &oidc.TokenSet{
 		IDToken:      idToken,
 		RefreshToken: token.RefreshToken,
+		AccessToken:  token.AccessToken,
 	}, nil
 }

--- a/pkg/oidc/oidc.go
+++ b/pkg/oidc/oidc.go
@@ -22,10 +22,11 @@ type Provider struct {
 type TokenSet struct {
 	IDToken      string
 	RefreshToken string
+	AccessToken  string
 }
 
 func (ts TokenSet) DecodeWithoutVerify() (*jwt.Claims, error) {
-	return jwt.DecodeWithoutVerify(ts.IDToken)
+	return jwt.DecodeWithoutVerify(ts.AccessToken)
 }
 
 func NewState() (string, error) {

--- a/pkg/tokencache/repository/repository.go
+++ b/pkg/tokencache/repository/repository.go
@@ -28,6 +28,7 @@ type Interface interface {
 type entity struct {
 	IDToken      string `json:"id_token,omitempty"`
 	RefreshToken string `json:"refresh_token,omitempty"`
+	AccessToken  string `json:"access_token,omitempty"`
 }
 
 // Repository provides access to the token cache on the local filesystem.
@@ -53,6 +54,7 @@ func (r *Repository) FindByKey(dir string, key tokencache.Key) (*oidc.TokenSet, 
 	return &oidc.TokenSet{
 		IDToken:      e.IDToken,
 		RefreshToken: e.RefreshToken,
+		AccessToken:  e.AccessToken,
 	}, nil
 }
 
@@ -73,6 +75,7 @@ func (r *Repository) Save(dir string, key tokencache.Key, tokenSet oidc.TokenSet
 	e := entity{
 		IDToken:      tokenSet.IDToken,
 		RefreshToken: tokenSet.RefreshToken,
+		AccessToken:  tokenSet.AccessToken,
 	}
 	if err := json.NewEncoder(f).Encode(&e); err != nil {
 		return fmt.Errorf("json encode error: %w", err)

--- a/pkg/usecases/authentication/authentication.go
+++ b/pkg/usecases/authentication/authentication.go
@@ -46,8 +46,8 @@ type GrantOptionSet struct {
 
 // Output represents an output DTO of the Authentication use-case.
 type Output struct {
-	AlreadyHasValidIDToken bool
-	TokenSet               oidc.TokenSet
+	AlreadyHasValidAccessToken bool
+	TokenSet                   oidc.TokenSet
 }
 
 // Authentication provides the internal use-case of authentication.
@@ -85,8 +85,8 @@ func (u *Authentication) Do(ctx context.Context, in Input) (*Output, error) {
 		if !claims.IsExpired(u.Clock) {
 			u.Logger.V(1).Infof("you already have a valid token until %s", claims.Expiry)
 			return &Output{
-				AlreadyHasValidIDToken: true,
-				TokenSet:               *in.CachedTokenSet,
+				AlreadyHasValidAccessToken: true,
+				TokenSet:                   *in.CachedTokenSet,
 			}, nil
 		}
 		u.Logger.V(1).Infof("you have an expired token at %s", claims.Expiry)

--- a/pkg/usecases/authentication/authentication_test.go
+++ b/pkg/usecases/authentication/authentication_test.go
@@ -54,7 +54,7 @@ func TestAuthentication_Do(t *testing.T) {
 			t.Errorf("Do returned error: %+v", err)
 		}
 		want := &Output{
-			AlreadyHasValidIDToken: true,
+			AlreadyHasValidAccessToken: true,
 			TokenSet: oidc.TokenSet{
 				IDToken: issuedIDToken,
 			},

--- a/pkg/usecases/credentialplugin/get_token.go
+++ b/pkg/usecases/credentialplugin/get_token.go
@@ -95,24 +95,24 @@ func (u *GetToken) Do(ctx context.Context, in Input) error {
 	if err != nil {
 		return fmt.Errorf("authentication error: %w", err)
 	}
-	idTokenClaims, err := authenticationOutput.TokenSet.DecodeWithoutVerify()
+	accessTokenClaims, err := authenticationOutput.TokenSet.DecodeWithoutVerify()
 	if err != nil {
 		return fmt.Errorf("you got an invalid token: %w", err)
 	}
-	u.Logger.V(1).Infof("you got a token: %s", idTokenClaims.Pretty)
+	u.Logger.V(1).Infof("you got a token: %s", accessTokenClaims.Pretty)
 
-	if authenticationOutput.AlreadyHasValidIDToken {
-		u.Logger.V(1).Infof("you already have a valid token until %s", idTokenClaims.Expiry)
+	if authenticationOutput.AlreadyHasValidAccessToken {
+		u.Logger.V(1).Infof("you already have a valid token until %s", accessTokenClaims.Expiry)
 	} else {
-		u.Logger.V(1).Infof("you got a valid token until %s", idTokenClaims.Expiry)
+		u.Logger.V(1).Infof("you got a valid token until %s", accessTokenClaims.Expiry)
 		if err := u.TokenCacheRepository.Save(in.TokenCacheDir, tokenCacheKey, authenticationOutput.TokenSet); err != nil {
 			return fmt.Errorf("could not write the token cache: %w", err)
 		}
 	}
 	u.Logger.V(1).Infof("writing the token to client-go")
 	out := credentialplugin.Output{
-		Token:  authenticationOutput.TokenSet.IDToken,
-		Expiry: idTokenClaims.Expiry,
+		Token:  authenticationOutput.TokenSet.AccessToken,
+		Expiry: accessTokenClaims.Expiry,
 	}
 	if err := u.Writer.Write(out); err != nil {
 		return fmt.Errorf("could not write the token to client-go: %w", err)

--- a/pkg/usecases/credentialplugin/get_token_test.go
+++ b/pkg/usecases/credentialplugin/get_token_test.go
@@ -205,8 +205,8 @@ func TestGetToken_Do(t *testing.T) {
 				GrantOptionSet: grantOptionSet,
 			}).
 			Return(&authentication.Output{
-				AlreadyHasValidIDToken: true,
-				TokenSet:               issuedTokenSet,
+				AlreadyHasValidAccessToken: true,
+				TokenSet:                   issuedTokenSet,
 			}, nil)
 		mockRepository := repository.NewMockInterface(t)
 		mockRepository.EXPECT().

--- a/pkg/usecases/standalone/standalone.go
+++ b/pkg/usecases/standalone/standalone.go
@@ -47,7 +47,6 @@ See https://github.com/int128/kubelogin for more.
 // If the current auth provider is not oidc, show the error.
 // If the kubeconfig has a valid token, do nothing.
 // Otherwise, update the kubeconfig.
-//
 type Standalone struct {
 	Authentication   authentication.Interface
 	KubeconfigLoader loader.Interface
@@ -102,7 +101,7 @@ func (u *Standalone) Do(ctx context.Context, in Input) error {
 		return fmt.Errorf("you got an invalid token: %w", err)
 	}
 	u.Logger.V(1).Infof("you got a token: %s", idTokenClaims.Pretty)
-	if authenticationOutput.AlreadyHasValidIDToken {
+	if authenticationOutput.AlreadyHasValidAccessToken {
 		u.Logger.Printf("You already have a valid token until %s", idTokenClaims.Expiry)
 		return nil
 	}

--- a/pkg/usecases/standalone/standalone_test.go
+++ b/pkg/usecases/standalone/standalone_test.go
@@ -119,7 +119,7 @@ func TestStandalone_Do(t *testing.T) {
 				},
 			}).
 			Return(&authentication.Output{
-				AlreadyHasValidIDToken: true,
+				AlreadyHasValidAccessToken: true,
 				TokenSet: oidc.TokenSet{
 					IDToken: issuedIDToken,
 				},


### PR DESCRIPTION
Hi !

Maybe i'm wrong but actually it's the id_token which is send to apiserver. This can lead to some problems if you have multiple audience in your token. Indeed if you have multiple audience there are not all in id_token but they are all in access token. If apiserver checks that the token contains all required audience the id_token is not enough. 

This PR allow to send the access_token instead of the id_token but still store the id_token in cache.