### PR TITLE
Add `--force-refresh` flag to `get-token` to refresh ID token

### DIFF
--- a/pkg/cmd/get_token.go
+++ b/pkg/cmd/get_token.go
@@ -21,6 +21,7 @@ type getTokenOptions struct {
 	TokenCacheDir         string
 	tlsOptions            tlsOptions
 	authenticationOptions authenticationOptions
+	ForceRefresh          bool
 }
 
 func (o *getTokenOptions) addFlags(f *pflag.FlagSet) {
@@ -30,6 +31,7 @@ func (o *getTokenOptions) addFlags(f *pflag.FlagSet) {
 	f.StringSliceVar(&o.ExtraScopes, "oidc-extra-scope", nil, "Scopes to request to the provider")
 	f.BoolVar(&o.UsePKCE, "oidc-use-pkce", false, "Force PKCE usage")
 	f.StringVar(&o.TokenCacheDir, "token-cache-dir", defaultTokenCacheDir, "Path to a directory for token cache")
+	f.BoolVar(&o.ForceRefresh, "force-refresh", false, "If set, refresh the ID token regardless of its expiration time")
 	o.tlsOptions.addFlags(f)
 	o.authenticationOptions.addFlags(f)
 }
@@ -82,6 +84,7 @@ func (cmd *GetToken) New() *cobra.Command {
 				TokenCacheDir:   o.TokenCacheDir,
 				GrantOptionSet:  grantOptionSet,
 				TLSClientConfig: o.tlsOptions.tlsClientConfig(),
+				ForceRefresh:    o.ForceRefresh,
 			}
 			if err := cmd.GetToken.Do(c.Context(), in); err != nil {
 				return fmt.Errorf("get-token: %w", err)

--- a/pkg/usecases/credentialplugin/get_token.go
+++ b/pkg/usecases/credentialplugin/get_token.go
@@ -37,6 +37,7 @@ type Input struct {
 	TokenCacheDir   string
 	GrantOptionSet  authentication.GrantOptionSet
 	TLSClientConfig tlsclientconfig.Config
+	ForceRefresh    bool
 }
 
 type GetToken struct {
@@ -90,6 +91,7 @@ func (u *GetToken) Do(ctx context.Context, in Input) error {
 		GrantOptionSet:  in.GrantOptionSet,
 		CachedTokenSet:  cachedTokenSet,
 		TLSClientConfig: in.TLSClientConfig,
+		ForceRefresh:    in.ForceRefresh,
 	}
 	authenticationOutput, err := u.Authentication.Do(ctx, authenticationInput)
 	if err != nil {


### PR DESCRIPTION
This PR adds a flag to `get-token` called `--force-refresh` which always renews the ID token regardless of its expiration time.

When `kubelogin` finds an existing `CachedTokenSet` it expects to have both an `IDToken` and a `RefreshToken`. It would then check the `IDToken`'s expiration time and might skip a refresh if it's still valid.

By using `--force-refresh` the check for the `IDToken`'s expiration time will always be skipped. This will trigger `kubelogin`'s normal token renewal procedure, either automatically (if a refresh token is present) or via the browser (if there's no cached token in the first place).

We have a use case where we prematurely want to refresh the ID token before its regular expiration time because we know the newly requested token will have additional properties that we want. Instructing `kubelogin get-token` to forcefully refresh the token on a case-by-case basis would help us a lot: Previously we would remove the cached token file on the file system completely, but that would also remove the refresh token and requires a dreadful login via the browser (at least it pops up for a moment). By keeping the cached token file (with the refresh token) in place and using `--force-refresh` instead, the process is seamless for the person using the client.

This PR misses tests but functionality has been tested manually. If the approach taken here seems reasonable to be merged I would also work on appropriate tests.

This should also fix https://github.com/int128/kubelogin/issues/659 /cc @Xartos