### PR TITLE
Added flag to let user set redirect uri for authcode-keyboard

### DIFF
--- a/pkg/cmd/authentication.go
+++ b/pkg/cmd/authentication.go
@@ -24,6 +24,7 @@ type authenticationOptions struct {
 	OpenURLAfterAuthentication string
 	RedirectURLHostname        string
 	AuthRequestExtraParams     map[string]string
+	CodeRedirectURL            string
 	Username                   string
 	Password                   string
 }
@@ -67,6 +68,7 @@ func (o *authenticationOptions) addFlags(f *pflag.FlagSet) {
 	f.StringVar(&o.OpenURLAfterAuthentication, "open-url-after-authentication", "", "[authcode] If set, open the URL in the browser after authentication")
 	f.StringVar(&o.RedirectURLHostname, "oidc-redirect-url-hostname", "localhost", "[authcode] Hostname of the redirect URL")
 	f.StringToStringVar(&o.AuthRequestExtraParams, "oidc-auth-request-extra-params", nil, "[authcode, authcode-keyboard] Extra query parameters to send with an authentication request")
+	f.StringVar(&o.CodeRedirectURL, "code-redirect-url", "", "[authcode-keybaord] URL to send the code to")
 	f.StringVar(&o.Username, "username", "", "[password] Username for resource owner password credentials grant")
 	f.StringVar(&o.Password, "password", "", "[password] Password for resource owner password credentials grant")
 }
@@ -93,6 +95,7 @@ func (o *authenticationOptions) grantOptionSet() (s authentication.GrantOptionSe
 	case o.GrantType == "authcode-keyboard":
 		s.AuthCodeKeyboardOption = &authcode.KeyboardOption{
 			AuthRequestExtraParams: o.AuthRequestExtraParams,
+			CodeRedirectURL:        o.CodeRedirectURL,
 		}
 	case o.GrantType == "password" || (o.GrantType == "auto" && o.Username != ""):
 		s.ROPCOption = &ropc.Option{

--- a/pkg/usecases/authentication/authcode/keyboard.go
+++ b/pkg/usecases/authentication/authcode/keyboard.go
@@ -16,6 +16,7 @@ const oobRedirectURI = "urn:ietf:wg:oauth:2.0:oob"
 
 type KeyboardOption struct {
 	AuthRequestExtraParams map[string]string
+	CodeRedirectURL        string
 }
 
 // Keyboard provides the authorization code flow with keyboard interactive.
@@ -38,11 +39,16 @@ func (u *Keyboard) Do(ctx context.Context, o *KeyboardOption, oidcClient client.
 	if err != nil {
 		return nil, fmt.Errorf("could not generate PKCE parameters: %w", err)
 	}
+	redirectUri := oobRedirectURI
+	if o.CodeRedirectURL != "" {
+		redirectUri = o.CodeRedirectURL
+	}
+
 	authCodeURL := oidcClient.GetAuthCodeURL(client.AuthCodeURLInput{
 		State:                  state,
 		Nonce:                  nonce,
 		PKCEParams:             p,
-		RedirectURI:            oobRedirectURI,
+		RedirectURI:            redirectUri,
 		AuthRequestExtraParams: o.AuthRequestExtraParams,
 	})
 	u.Logger.Printf("Please visit the following URL in your browser: %s", authCodeURL)
@@ -56,7 +62,7 @@ func (u *Keyboard) Do(ctx context.Context, o *KeyboardOption, oidcClient client.
 		Code:        code,
 		PKCEParams:  p,
 		Nonce:       nonce,
-		RedirectURI: oobRedirectURI,
+		RedirectURI: redirectUri,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("could not exchange the authorization code: %w", err)


### PR DESCRIPTION
This enables users to redirect the auth code to an endpoint they control to present it to the user.  This allows `authcode-keyboard` to not only support `urn:ietf:wg:oauth:2.0:oob`.  This allows IDPs that do not support that URI to get auth codes.