### PR TITLE
Respect `KUBECACHEDIR` environment variable

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"runtime"
+	"os"
 
 	"github.com/google/wire"
 	"github.com/int128/kubelogin/pkg/infrastructure/logger"
@@ -23,8 +24,17 @@ type Interface interface {
 	Run(ctx context.Context, args []string, version string) int
 }
 
+func getDefaultTokenCacheDir(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}
+
 var defaultListenAddress = []string{"127.0.0.1:8000", "127.0.0.1:18000"}
-var defaultTokenCacheDir = filepath.Join("~", ".kube", "cache", "oidc-login")
+var defaultTokenCacheDir = filepath.Join(
+	getDefaultTokenCacheDir("KUBECACHEDIR", filepath.Join("~", ".kube", "cache")),
+	"oidc-login")
 
 const defaultAuthenticationTimeoutSec = 180
 


### PR DESCRIPTION
This adds a check for the existence of a (non-empty) `KUBECACHEDIR` environment variable that will be used to construct the cache directory path if present.

Tested locally with variable set/unset and directory empty/non-empty, works fine.

Programmatic tests aren't there yet, I'd love a pointer on how you'd want to harness testing depending on an environment variable, since I only see usage of tests for e.g. `$KUBECONFIG` in `acceptance_test`/`integration_test`