### PR TITLE
fix(docker): Bump to distroless debian12 for golang:1.21 binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ COPY main.go .
 COPY pkg pkg
 RUN go build
 
-FROM gcr.io/distroless/base-debian10
+FROM gcr.io/distroless/base-debian12
 COPY --from=builder /builder/kubelogin /
 ENTRYPOINT ["/kubelogin"]


### PR DESCRIPTION
golang:1.21 binaries are compiled to require at least GLIBC 2.36, debian 10 is only 2.31.