### PR TITLE
Build multi-architectures image in single job

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -24,12 +24,9 @@ on:
 
 jobs:
   build:
-    if: github.event_name == 'pull_request'
     uses: int128/docker-build-workflow/.github/workflows/build.yaml@v1
-
-  build-multi-architecture:
-    if: github.event_name != 'pull_request'
-    uses: int128/docker-build-workflow/.github/workflows/build-multi-architecture.yaml@v1
     with:
       platforms: |
-        ["linux/amd64", "linux/arm64", "linux/ppc64le"]
+        linux/amd64
+        linux/arm64
+        linux/ppc64le


### PR DESCRIPTION
To remove https://github.com/int128/docker-build-workflow/blob/f7fa9215ec1b908c610357e09fb47c3611f8faf8/.github/workflows/build-multi-architecture.yaml