### PR TITLE
Close browser window on successful authentication

### DIFF
--- a/pkg/usecases/authentication/authcode/browser_html.go
+++ b/pkg/usecases/authentication/authcode/browser_html.go
@@ -13,7 +13,8 @@ const BrowserSuccessHTML = `
 	<meta charset="UTF-8">
 	<title>Authenticated</title>
 	<script>
-		window.close()
+		// Only works with Firefox if 'dom.allow_scripts_to_close_windows' is set to True
+		window.open('','_self').close();
 	</script>
 	<style>
 		body {


### PR DESCRIPTION
This fixes the logic for closing browser windows. Current version works with Google Chrome, and with Firefox if the config "dom.allow_scripts_to_close_windows" is set to true. I have tested with Safari with no success.