### PR TITLE
Lock dedicated file instead of token cache file

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -29,7 +29,14 @@ jobs:
         golangci-lint-version: v1.61.0
 
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -7,6 +7,8 @@ on:
     paths:
       - .github/workflows/go.yaml
       - pkg/**
+      - integration_test/**
+      - mocks/**
       - tools/**
       - go.*
     tags:
@@ -17,6 +19,8 @@ on:
     paths:
       - .github/workflows/go.yaml
       - pkg/**
+      - integration_test/**
+      - mocks/**
       - tools/**
       - go.*
 
@@ -29,6 +33,17 @@ jobs:
         golangci-lint-version: v1.61.0
 
   test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+      - run: go test -v -race ./pkg/...
+
+  integration-test:
     strategy:
       fail-fast: false
       matrix:
@@ -44,7 +59,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
-      - run: go test -v -race ./...
+      - run: go test -v -race ./integration_test/...
 
   generate:
     runs-on: ubuntu-latest

--- a/pkg/tokencache/repository/repository.go
+++ b/pkg/tokencache/repository/repository.go
@@ -83,20 +83,20 @@ func (r *Repository) Save(dir string, key tokencache.Key, tokenSet oidc.TokenSet
 	return nil
 }
 
-func (r *Repository) Lock(dir string, key tokencache.Key) (io.Closer, error) {
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		return nil, fmt.Errorf("could not create directory %s: %w", dir, err)
+func (r *Repository) Lock(tokenCacheDir string, key tokencache.Key) (io.Closer, error) {
+	if err := os.MkdirAll(tokenCacheDir, 0700); err != nil {
+		return nil, fmt.Errorf("could not create directory %s: %w", tokenCacheDir, err)
 	}
-	filename, err := computeFilename(key)
+	keyDigest, err := computeFilename(key)
 	if err != nil {
 		return nil, fmt.Errorf("could not compute the key: %w", err)
 	}
-	p := filepath.Join(dir, filename)
-	f := flock.New(p)
-	if err := f.Lock(); err != nil {
-		return nil, fmt.Errorf("could not lock the cache file %s: %w", p, err)
+	lockFilepath := filepath.Join(tokenCacheDir, keyDigest+".lock")
+	lockFile := flock.New(lockFilepath)
+	if err := lockFile.Lock(); err != nil {
+		return nil, fmt.Errorf("could not lock the cache file %s: %w", lockFilepath, err)
 	}
-	return f, nil
+	return lockFile, nil
 }
 
 func computeFilename(key tokencache.Key) (string, error) {

--- a/pkg/tokencache/repository/repository.go
+++ b/pkg/tokencache/repository/repository.go
@@ -91,6 +91,8 @@ func (r *Repository) Lock(tokenCacheDir string, key tokencache.Key) (io.Closer, 
 	if err != nil {
 		return nil, fmt.Errorf("could not compute the key: %w", err)
 	}
+	// Do not lock the token cache file.
+	// https://github.com/int128/kubelogin/issues/1144
 	lockFilepath := filepath.Join(tokenCacheDir, keyDigest+".lock")
 	lockFile := flock.New(lockFilepath)
 	if err := lockFile.Lock(); err != nil {


### PR DESCRIPTION
This changes the lock from the token cache file (`~/.kube/cache/oidc-login/DIGEST`) to a dedicated file (`~/.kube/cache/oidc-login/DIGEST.lock`). It will resolve the error on Windows.

## Refs
- https://github.com/int128/kubelogin/pull/1126
- https://github.com/int128/kubelogin/issues/1144
- https://github.com/int128/kubelogin/issues/628
