### PR TITLE
Enable keyring in system-test

### DIFF
--- a/.github/workflows/system-test.yaml
+++ b/.github/workflows/system-test.yaml
@@ -28,15 +28,13 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: go.sum
 
-      - run: sudo apt update
-      # For certutil
+      - run: sudo apt-get update
+      # Install certutil.
       # https://packages.ubuntu.com/xenial/libnss3-tools
-      - run: sudo apt install --no-install-recommends -y libnss3-tools
-      # For keyring
+      # Install keyring related packages.
       # https://github.com/zalando/go-keyring/issues/45
-      - run: sudo apt install --no-install-recommends -y dbus-x11 gnome-keyring
+      - run: sudo apt-get install --no-install-recommends -y libnss3-tools dbus-x11 gnome-keyring
 
-      - run: mkdir -p ~/.pki/nssdb
       - run: echo '127.0.0.1 dex-server' | sudo tee -a /etc/hosts
 
       - run: make -C system_test -j3

--- a/.github/workflows/system-test.yaml
+++ b/.github/workflows/system-test.yaml
@@ -28,12 +28,15 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: go.sum
 
-      # for certutil
-      # https://packages.ubuntu.com/xenial/libnss3-tools
       - run: sudo apt update
-      - run: sudo apt install -y libnss3-tools
-      - run: mkdir -p ~/.pki/nssdb
+      # For certutil
+      # https://packages.ubuntu.com/xenial/libnss3-tools
+      - run: sudo apt install --no-install-recommends -y libnss3-tools
+      # For keyring
+      # https://github.com/zalando/go-keyring/issues/45
+      - run: sudo apt install --no-install-recommends -y dbus-x11 gnome-keyring
 
+      - run: mkdir -p ~/.pki/nssdb
       - run: echo '127.0.0.1 dex-server' | sudo tee -a /etc/hosts
 
       - run: make -C system_test -j3

--- a/system_test/Makefile
+++ b/system_test/Makefile
@@ -1,11 +1,12 @@
 CERT_DIR := cert
 
-.PHONY: test
-test: setup
-	dbus-run-session -- $(MAKE) -C login test
+.PHONY: test-with-dbus-session
+test-with-dbus-session:
+	dbus-run-session -- $(MAKE) test
 
-.PHONY: setup
-setup: dex cluster setup-chrome
+.PHONY: test
+test: dex cluster setup-chrome setup-keyring
+	$(MAKE) -C login
 
 .PHONY: dex
 dex: cert
@@ -15,10 +16,17 @@ dex: cert
 cluster: cert
 	$(MAKE) -C cluster
 
+# Add the server certificate of dex to the trust store for Chrome.
 .PHONY: setup-chrome
 setup-chrome: cert
-	# Add the dex server certificate to the trust store
+	mkdir -p $(HOME)/.pki/nssdb
 	certutil -A -d sql:$(HOME)/.pki/nssdb -n dex -i $(CERT_DIR)/ca.crt -t "TC,,"
+
+# Start gnome-keyring-daemon.
+# https://github.com/zalando/go-keyring/issues/45
+.PHONY: setup-keyring
+setup-keyring:
+	echo password | gnome-keyring-daemon --unlock
 
 .PHONY: cert
 cert:

--- a/system_test/Makefile
+++ b/system_test/Makefile
@@ -1,8 +1,8 @@
 CERT_DIR := cert
 
-.PHONY: login
-login: setup
-	$(MAKE) -C login
+.PHONY: test
+test: setup
+	dbus-run-session -- $(MAKE) -C login test
 
 .PHONY: setup
 setup: dex cluster setup-chrome
@@ -17,7 +17,7 @@ cluster: cert
 
 .PHONY: setup-chrome
 setup-chrome: cert
-	# add the dex server certificate to the trust store
+	# Add the dex server certificate to the trust store
 	certutil -A -d sql:$(HOME)/.pki/nssdb -n dex -i $(CERT_DIR)/ca.crt -t "TC,,"
 
 .PHONY: cert

--- a/system_test/login/Makefile
+++ b/system_test/login/Makefile
@@ -44,7 +44,7 @@ $(BIN_DIR)/chromelogin: $(wildcard chromelogin/*.go)
 
 .PHONY: setup-keyring
 setup-keyring:
-	gnome-keyring-daemon --unlock <<< password
+	gnome-keyring-daemon --unlock < /dev/null
 
 .PHONY: clean
 clean:

--- a/system_test/login/Makefile
+++ b/system_test/login/Makefile
@@ -8,7 +8,7 @@ KUBECONFIG := ../cluster/kubeconfig.yaml
 export KUBECONFIG
 
 .PHONY: test
-test: build
+test: build setup-keyring
 	# see the setup instruction
 	kubectl oidc-login setup \
 		--oidc-issuer-url=https://dex-server:10443/dex \
@@ -41,6 +41,10 @@ $(BIN_DIR)/kubectl-oidc_login:
 
 $(BIN_DIR)/chromelogin: $(wildcard chromelogin/*.go)
 	go build -o $@ ./chromelogin
+
+.PHONY: setup-keyring
+setup-keyring:
+	gnome-keyring-daemon --unlock <<< password
 
 .PHONY: clean
 clean:

--- a/system_test/login/Makefile
+++ b/system_test/login/Makefile
@@ -8,7 +8,7 @@ KUBECONFIG := ../cluster/kubeconfig.yaml
 export KUBECONFIG
 
 .PHONY: test
-test: build setup-keyring
+test: build
 	# see the setup instruction
 	kubectl oidc-login setup \
 		--oidc-issuer-url=https://dex-server:10443/dex \
@@ -41,10 +41,6 @@ $(BIN_DIR)/kubectl-oidc_login:
 
 $(BIN_DIR)/chromelogin: $(wildcard chromelogin/*.go)
 	go build -o $@ ./chromelogin
-
-.PHONY: setup-keyring
-setup-keyring:
-	echo password | gnome-keyring-daemon --unlock
 
 .PHONY: clean
 clean:

--- a/system_test/login/Makefile
+++ b/system_test/login/Makefile
@@ -29,8 +29,7 @@ test: build
 		--exec-arg=--oidc-client-secret=YOUR_CLIENT_SECRET \
 		--exec-arg=--oidc-extra-scope=email \
 		--exec-arg=--certificate-authority=$(CERT_DIR)/ca.crt \
-		--exec-arg=--browser-command=$(BIN_DIR)/chromelogin \
-		--exec-arg=--no-keyring
+		--exec-arg=--browser-command=$(BIN_DIR)/chromelogin
 	# make sure we can access the cluster
 	kubectl --user=oidc cluster-info
 

--- a/system_test/login/Makefile
+++ b/system_test/login/Makefile
@@ -44,7 +44,7 @@ $(BIN_DIR)/chromelogin: $(wildcard chromelogin/*.go)
 
 .PHONY: setup-keyring
 setup-keyring:
-	gnome-keyring-daemon --unlock < /dev/null
+	echo password | gnome-keyring-daemon --unlock
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Follow up https://github.com/int128/kubelogin/pull/973.

References:

- https://github.com/zalando/go-keyring/issues/45
- https://keyring.readthedocs.io/en/latest/#using-keyring-on-headless-linux-systems
