### PR TITLE
Add --token-cache-storage flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,14 @@ NAME                          READY   STATUS    RESTARTS   AGE
 echoserver-86c78fdccd-nzmd5   1/1     Running   0          26d
 ```
 
-Kubelogin writes the ID token and refresh token to the token cache file.
+Kubelogin stores the ID token and refresh token to the token cache storage.
+If the OS keyring is available, it stores the token cache to the keyring.
+Otherwise, it stores the token cache to the file system.
 
-If the cached ID token is valid, kubelogin just returns it.
-If the cached ID token has expired, kubelogin will refresh the token using the refresh token.
-If the refresh token has expired, kubelogin will perform re-authentication (you will have to login via browser again).
+Kubelogin refreshes the expired token cache.
+If the ID token is valid, it just returns it.
+If the ID token has expired, it will refresh the token using the refresh token.
+If the refresh token has expired, it will perform re-authentication.
 
 ### Troubleshoot
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,8 +13,9 @@ Flags:
       --oidc-extra-scope strings                        Scopes to request to the provider
       --oidc-use-pkce                                   Force PKCE usage
       --oidc-use-access-token                           Instead of using the id_token, use the access_token to authenticate to Kubernetes
-      --token-cache-dir string                          Path to a directory for token cache (default "~/.kube/cache/oidc-login")
       --force-refresh                                   If set, refresh the ID token regardless of its expiration time
+      --token-cache-dir string                          Path to a directory of the token cache (default "~/.kube/cache/oidc-login")
+      --token-cache-storage string                      Storage for the token cache. One of (auto|keyring|disk) (default "auto")
       --certificate-authority stringArray               Path to a cert file for the certificate authority
       --certificate-authority-data stringArray          Base64 encoded cert for the certificate authority
       --insecure-skip-tls-verify                        If set, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -87,6 +88,20 @@ You can use your self-signed certificate for the provider.
 
 You can set the following environment variables if you are behind a proxy: `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY`.
 See also [net/http#ProxyFromEnvironment](https://golang.org/pkg/net/http/#ProxyFromEnvironment).
+
+### Token cache
+
+Kubelogin stores the token cache to the OS keyring if available.
+It depends on [zalando/go-keyring](https://github.com/zalando/go-keyring) for the keyring storage.
+
+You can enforce the storage by `--token-cache-storage`.
+
+```yaml
+# Force to use the OS keyring
+- --token-cache-storage=keyring
+# Force to use the file system
+- --token-cache-storage=disk
+```
 
 ### Home directory expansion
 

--- a/integration_test/credetial_plugin_test.go
+++ b/integration_test/credetial_plugin_test.go
@@ -402,10 +402,10 @@ func runGetToken(t *testing.T, ctx context.Context, cfg getTokenConfig) {
 		"kubelogin",
 		"get-token",
 		"--token-cache-dir", cfg.tokenCacheDir,
+		"--token-cache-storage", "disk",
 		"--oidc-issuer-url", cfg.issuerURL,
 		"--oidc-client-id", "kubernetes",
 		"--listen-address", "127.0.0.1:0",
-		"--no-keyring",
 	}, cfg.args...), "latest")
 	if exitCode != 0 {
 		t.Errorf("exit status wants 0 but %d", exitCode)

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -120,6 +120,7 @@ func TestCmd_Run(t *testing.T) {
 					},
 					TokenCacheConfig: tokencache.Config{
 						Directory: filepath.Join(userHomeDir, ".kube/cache/oidc-login"),
+						Storage:   tokencache.StorageAuto,
 					},
 					GrantOptionSet: authentication.GrantOptionSet{
 						AuthCodeBrowserOption: &authcode.BrowserOption{
@@ -138,6 +139,7 @@ func TestCmd_Run(t *testing.T) {
 					"--oidc-client-secret", "YOUR_CLIENT_SECRET",
 					"--oidc-extra-scope", "email",
 					"--oidc-extra-scope", "profile",
+					"--token-cache-storage", "disk",
 					"-v1",
 				},
 				in: credentialplugin.Input{
@@ -149,6 +151,7 @@ func TestCmd_Run(t *testing.T) {
 					},
 					TokenCacheConfig: tokencache.Config{
 						Directory: filepath.Join(userHomeDir, ".kube/cache/oidc-login"),
+						Storage:   tokencache.StorageDisk,
 					},
 					GrantOptionSet: authentication.GrantOptionSet{
 						AuthCodeBrowserOption: &authcode.BrowserOption{
@@ -174,6 +177,7 @@ func TestCmd_Run(t *testing.T) {
 					},
 					TokenCacheConfig: tokencache.Config{
 						Directory: filepath.Join(userHomeDir, ".kube/cache/oidc-login"),
+						Storage:   tokencache.StorageAuto,
 					},
 					GrantOptionSet: authentication.GrantOptionSet{
 						AuthCodeBrowserOption: &authcode.BrowserOption{
@@ -201,6 +205,7 @@ func TestCmd_Run(t *testing.T) {
 					},
 					TokenCacheConfig: tokencache.Config{
 						Directory: filepath.Join(userHomeDir, ".kube/oidc-cache"),
+						Storage:   tokencache.StorageAuto,
 					},
 					GrantOptionSet: authentication.GrantOptionSet{
 						AuthCodeBrowserOption: &authcode.BrowserOption{

--- a/pkg/cmd/get_token.go
+++ b/pkg/cmd/get_token.go
@@ -72,6 +72,10 @@ func (cmd *GetToken) New() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("get-token: %w", err)
 			}
+			tokenCacheConfig, err := o.tokenCacheOptions.tokenCacheConfig()
+			if err != nil {
+				return fmt.Errorf("get-token: %w", err)
+			}
 			in := credentialplugin.Input{
 				Provider: oidc.Provider{
 					IssuerURL:      o.IssuerURL,
@@ -82,7 +86,7 @@ func (cmd *GetToken) New() *cobra.Command {
 					ExtraScopes:    o.ExtraScopes,
 				},
 				ForceRefresh:     o.ForceRefresh,
-				TokenCacheConfig: o.tokenCacheOptions.tokenCacheConfig(),
+				TokenCacheConfig: tokenCacheConfig,
 				GrantOptionSet:   grantOptionSet,
 				TLSClientConfig:  o.tlsOptions.tlsClientConfig(),
 			}


### PR DESCRIPTION
This replaces the flags of `--force-keyring` and `--no-keyring` with `--token-cache-storage`. I think it is better design if kubelogin will support more storages.
