### PR TITLE
Rename flag to --oidc-pkce-method and improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ users:
           - get-token
           - --oidc-issuer-url=ISSUER_URL
           - --oidc-client-id=YOUR_CLIENT_ID
-          - --oidc-client-secret=YOUR_CLIENT_SECRET
 ```
 
 See [setup guide](docs/setup.md) for more.
@@ -91,7 +90,7 @@ Kubelogin will ask you to login via browser again if the token cache file does n
 You can dump claims of an ID token by `setup` command.
 
 ```console
-% kubectl oidc-login setup --oidc-issuer-url https://accounts.google.com --oidc-client-id REDACTED --oidc-client-secret REDACTED
+% kubectl oidc-login setup --oidc-issuer-url https://accounts.google.com --oidc-client-id REDACTED
 ...
 You got a token with the following claims:
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -27,7 +27,6 @@ Replace the following variables in the later sections.
 | -------------------- | -------------------------------- |
 | `ISSUER_URL`         | `https://accounts.google.com`    |
 | `YOUR_CLIENT_ID`     | `xxx.apps.googleusercontent.com` |
-| `YOUR_CLIENT_SECRET` | random string                    |
 
 ### Keycloak
 
@@ -59,7 +58,6 @@ Replace the following variables in the later sections.
 | -------------------- | ----------------------------------------------------- |
 | `ISSUER_URL`         | `https://keycloak.example.com/auth/realms/YOUR_REALM` |
 | `YOUR_CLIENT_ID`     | `YOUR_CLIENT_ID`                                      |
-| `YOUR_CLIENT_SECRET` | random string                                         |
 
 ### Dex with GitHub
 
@@ -155,8 +153,7 @@ Run the following command:
 ```sh
 kubectl oidc-login setup \
   --oidc-issuer-url=ISSUER_URL \
-  --oidc-client-id=YOUR_CLIENT_ID \
-  --oidc-client-secret=YOUR_CLIENT_SECRET
+  --oidc-client-id=YOUR_CLIENT_ID
 ```
 
 It launches the browser and navigates to `http://localhost:8000`.
@@ -219,8 +216,7 @@ kubectl config set-credentials oidc \
   --exec-arg=oidc-login \
   --exec-arg=get-token \
   --exec-arg=--oidc-issuer-url=ISSUER_URL \
-  --exec-arg=--oidc-client-id=YOUR_CLIENT_ID \
-  --exec-arg=--oidc-client-secret=YOUR_CLIENT_SECRET
+  --exec-arg=--oidc-client-id=YOUR_CLIENT_ID
 ```
 
 ## 6. Verify cluster access

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -87,7 +87,7 @@ you can enforce the code challenge method by `--oidc-pkce-method`.
 - --oidc-pkce-method=S256
 ```
 
-For the most providers, kubelogin automatically uses the PKCE by default.
+For the most providers, you don't need to set this option explicitly.
 
 ### CA certificate
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,7 +20,7 @@ Flags:
       --insecure-skip-tls-verify                        [SECURITY RISK] If set, the server's certificate will not be checked for validity
       --tls-renegotiation-once                          If set, allow a remote server to request renegotiation once per connection
       --tls-renegotiation-freely                        If set, allow a remote server to repeatedly request renegotiation
-      --oidc-pkce-method string                         PKCE method. By default, PKCE is automatically enabled if the provider supports it. One of (auto|no|S256) (default "auto")
+      --oidc-pkce-method string                         PKCE code challenge method. Automatically determined by default. One of (auto|no|S256) (default "auto")
       --grant-type string                               Authorization grant type to use. One of (auto|authcode|authcode-keyboard|password|device-code) (default "auto")
       --listen-address strings                          [authcode] Address to bind to the local server. If multiple addresses are set, it will try binding in order (default [127.0.0.1:8000,127.0.0.1:18000])
       --skip-open-browser                               [authcode] Do not open the browser automatically
@@ -77,9 +77,17 @@ You can set the extra scopes to request to the provider by `--oidc-extra-scope`.
 
 ### PKCE
 
-Kubelogin automatically enables PKCE if the provider supports it.
-It is determined by the `code_challenge_methods_supported` claim of the OpenID Connect Discovery document.
-If your provider does not provide a valid claim, you can enforce the PKCE method by `--oidc-pkce-method`.
+Kubelogin automatically uses the PKCE if the provider supports it.
+It determines the code challenge method by the `code_challenge_methods_supported` claim of the OpenID Connect Discovery document.
+
+If your provider does not return a valid `code_challenge_methods_supported` claim,
+you can enforce the code challenge method by `--oidc-pkce-method`.
+
+```yaml
+- --oidc-pkce-method=S256
+```
+
+For the most providers, kubelogin automatically uses the PKCE by default.
 
 ### CA certificate
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,7 +11,6 @@ Flags:
       --oidc-client-id string                           Client ID of the provider (mandatory)
       --oidc-client-secret string                       Client secret of the provider
       --oidc-extra-scope strings                        Scopes to request to the provider
-      --oidc-use-pkce                                   Force PKCE even if the provider does not support it
       --oidc-use-access-token                           Instead of using the id_token, use the access_token to authenticate to Kubernetes
       --force-refresh                                   If set, refresh the ID token regardless of its expiration time
       --token-cache-dir string                          Path to a directory of the token cache (default "~/.kube/cache/oidc-login")
@@ -21,6 +20,7 @@ Flags:
       --insecure-skip-tls-verify                        [SECURITY RISK] If set, the server's certificate will not be checked for validity
       --tls-renegotiation-once                          If set, allow a remote server to request renegotiation once per connection
       --tls-renegotiation-freely                        If set, allow a remote server to repeatedly request renegotiation
+      --oidc-pkce-method string                         PKCE method. By default, PKCE is automatically enabled if the provider supports it. One of (auto|no|S256) (default "auto")
       --grant-type string                               Authorization grant type to use. One of (auto|authcode|authcode-keyboard|password|device-code) (default "auto")
       --listen-address strings                          [authcode] Address to bind to the local server. If multiple addresses are set, it will try binding in order (default [127.0.0.1:8000,127.0.0.1:18000])
       --skip-open-browser                               [authcode] Do not open the browser automatically
@@ -74,6 +74,12 @@ You can set the extra scopes to request to the provider by `--oidc-extra-scope`.
 - --oidc-extra-scope=email
 - --oidc-extra-scope=profile
 ```
+
+### PKCE
+
+Kubelogin automatically enables PKCE if the provider supports it.
+It is determined by the `code_challenge_methods_supported` claim of the OpenID Connect Discovery document.
+If your provider does not provide a valid claim, you can enforce the PKCE method by `--oidc-pkce-method`.
 
 ### CA certificate
 

--- a/pkg/cmd/pkce.go
+++ b/pkg/cmd/pkce.go
@@ -16,11 +16,11 @@ type pkceOptions struct {
 }
 
 func (o *pkceOptions) addFlags(f *pflag.FlagSet) {
-	f.BoolVar(&o.UsePKCE, "oidc-use-pkce", false, "Force PKCE S256 method")
-	if err := f.MarkDeprecated("oidc-use-pkce", "use --oidc-pkce-method instead. Note that PKCE is automatically enabled by default."); err != nil {
+	f.BoolVar(&o.UsePKCE, "oidc-use-pkce", false, "Force PKCE S256 code challenge method")
+	if err := f.MarkDeprecated("oidc-use-pkce", "use --oidc-pkce-method instead. For the most providers, you don't need to set the flag."); err != nil {
 		panic(err)
 	}
-	f.StringVar(&o.PKCEMethod, "oidc-pkce-method", "auto", fmt.Sprintf("PKCE method. By default, PKCE is automatically enabled if the provider supports it. One of (%s)", allPKCEMethods))
+	f.StringVar(&o.PKCEMethod, "oidc-pkce-method", "auto", fmt.Sprintf("PKCE code challenge method. Automatically determined by default. One of (%s)", allPKCEMethods))
 }
 
 func (o *pkceOptions) pkceMethod() (oidc.PKCEMethod, error) {

--- a/pkg/cmd/pkce.go
+++ b/pkg/cmd/pkce.go
@@ -17,7 +17,9 @@ type pkceOptions struct {
 
 func (o *pkceOptions) addFlags(f *pflag.FlagSet) {
 	f.BoolVar(&o.UsePKCE, "oidc-use-pkce", false, "Force PKCE S256 method")
-	f.MarkDeprecated("oidc-use-pkce", "use --oidc-pkce-method instead. Note that PKCE is automatically enabled by default.")
+	if err := f.MarkDeprecated("oidc-use-pkce", "use --oidc-pkce-method instead. Note that PKCE is automatically enabled by default."); err != nil {
+		panic(err)
+	}
 	f.StringVar(&o.PKCEMethod, "oidc-pkce-method", "auto", fmt.Sprintf("PKCE method. By default, PKCE is automatically enabled if the provider supports it. One of (%s)", allPKCEMethods))
 }
 

--- a/pkg/cmd/pkce.go
+++ b/pkg/cmd/pkce.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/int128/kubelogin/pkg/oidc"
+	"github.com/spf13/pflag"
+)
+
+var allPKCEMethods = strings.Join([]string{"auto", "no", "S256"}, "|")
+
+type pkceOptions struct {
+	UsePKCE    bool
+	PKCEMethod string
+}
+
+func (o *pkceOptions) addFlags(f *pflag.FlagSet) {
+	f.BoolVar(&o.UsePKCE, "oidc-use-pkce", false, "Force PKCE S256 method")
+	f.MarkDeprecated("oidc-use-pkce", "use --oidc-pkce-method instead. Note that PKCE is automatically enabled by default.")
+	f.StringVar(&o.PKCEMethod, "oidc-pkce-method", "auto", fmt.Sprintf("PKCE method. By default, PKCE is automatically enabled if the provider supports it. One of (%s)", allPKCEMethods))
+}
+
+func (o *pkceOptions) pkceMethod() (oidc.PKCEMethod, error) {
+	if o.UsePKCE {
+		return oidc.PKCEMethodS256, nil
+	}
+	switch o.PKCEMethod {
+	case "auto":
+		return oidc.PKCEMethodAuto, nil
+	case "no":
+		return oidc.PKCEMethodNo, nil
+	case "S256":
+		return oidc.PKCEMethodS256, nil
+	default:
+		return 0, fmt.Errorf("oidc-pkce-method must be one of (%s)", allPKCEMethods)
+	}
+}

--- a/pkg/oidc/oidc.go
+++ b/pkg/oidc/oidc.go
@@ -15,9 +15,18 @@ type Provider struct {
 	ClientID       string
 	ClientSecret   string   // optional
 	ExtraScopes    []string // optional
-	ForcePKCE      bool     // optional
-	UseAccessToken bool     // optional
+	PKCEMethod     PKCEMethod
+	UseAccessToken bool
 }
+
+// PKCEMethod represents a preferred method of PKCE.
+type PKCEMethod int
+
+const (
+	PKCEMethodAuto PKCEMethod = iota
+	PKCEMethodNo
+	PKCEMethodS256
+)
 
 // TokenSet represents a set of ID token and refresh token.
 type TokenSet struct {

--- a/pkg/pkce/pkce.go
+++ b/pkg/pkce/pkce.go
@@ -10,13 +10,12 @@ import (
 	"fmt"
 )
 
-type Method string
+type Method int
 
 const (
-	NoMethod Method = ""
-
 	// Code challenge methods defined as https://tools.ietf.org/html/rfc7636#section-4.3
-	MethodS256 Method = "S256"
+	NoMethod Method = iota
+	MethodS256
 )
 
 // Params represents a set of the PKCE parameters.
@@ -59,7 +58,7 @@ func computeS256(b []byte) Params {
 	_, _ = s.Write([]byte(v))
 	return Params{
 		CodeChallenge:       base64URLEncode(s.Sum(nil)),
-		CodeChallengeMethod: string(MethodS256),
+		CodeChallengeMethod: "S256",
 		CodeVerifier:        v,
 	}
 }

--- a/pkg/usecases/setup/stage2.go
+++ b/pkg/usecases/setup/stage2.go
@@ -73,9 +73,10 @@ type Stage2Input struct {
 	ClientID          string
 	ClientSecret      string
 	ExtraScopes       []string // optional
-	UsePKCE           bool     // optional
 	UseAccessToken    bool     // optional
 	ListenAddressArgs []string // non-nil if set by the command arg
+	PKCEMethod        oidc.PKCEMethod
+	PKCEMethodArg     string
 	GrantOptionSet    authentication.GrantOptionSet
 	TLSClientConfig   tlsclientconfig.Config
 }
@@ -88,7 +89,7 @@ func (u *Setup) DoStage2(ctx context.Context, in Stage2Input) error {
 			ClientID:       in.ClientID,
 			ClientSecret:   in.ClientSecret,
 			ExtraScopes:    in.ExtraScopes,
-			ForcePKCE:      in.UsePKCE,
+			PKCEMethod:     in.PKCEMethod,
 			UseAccessToken: in.UseAccessToken,
 		},
 		GrantOptionSet:  in.GrantOptionSet,
@@ -127,8 +128,8 @@ func makeCredentialPluginArgs(in Stage2Input) []string {
 	for _, extraScope := range in.ExtraScopes {
 		args = append(args, "--oidc-extra-scope="+extraScope)
 	}
-	if in.UsePKCE {
-		args = append(args, "--oidc-use-pkce")
+	if in.PKCEMethodArg != "" {
+		args = append(args, "--oidc-pkce-method="+in.PKCEMethodArg)
 	}
 	if in.UseAccessToken {
 		args = append(args, "--oidc-use-access-token")

--- a/pkg/usecases/setup/stage2_test.go
+++ b/pkg/usecases/setup/stage2_test.go
@@ -70,7 +70,7 @@ func Test_makeCredentialPluginArgs(t *testing.T) {
 		ClientID:          "test_kid",
 		ClientSecret:      "test_ksecret",
 		ExtraScopes:       []string{"groups"},
-		UsePKCE:           true,
+		PKCEMethodArg:     "S256",
 		ListenAddressArgs: []string{"127.0.0.1:8080", "127.0.0.1:8888"},
 		GrantOptionSet: authentication.GrantOptionSet{
 			AuthCodeBrowserOption: &authcode.BrowserOption{
@@ -94,7 +94,7 @@ func Test_makeCredentialPluginArgs(t *testing.T) {
 		"--oidc-client-id=test_kid",
 		"--oidc-client-secret=test_ksecret",
 		"--oidc-extra-scope=groups",
-		"--oidc-use-pkce",
+		"--oidc-pkce-method=S256",
 		"--certificate-authority=/path/to/ca.crt",
 		"--certificate-authority-data=base64encoded1",
 		"--insecure-skip-tls-verify",


### PR DESCRIPTION
Resolves https://github.com/int128/kubelogin/issues/1227.
Resolves https://github.com/int128/kubelogin/issues/858.

## Changes
### Flags
This changes the flag `--oidc-use-pkce` to `--oidc-pkce-method`. It does not change the default behavior.

- Before
  - PKCE is automatically used if the provider supports it.
  - `--oidc-use-pkce` forces to use PKCE.
- After
  - PKCE is automatically used if the provider supports it.
  - `--oidc-use-pkce` is deprecated. Equivalent to `--oidc-pkce-method=S256`.
  - `--oidc-pkce-method` is added. It forces to use PKCE. Default to `--oidc-pkce-method=auto`.

### Docs
This also improves the docs:

- Remove the client secret from README
- Add PKCE section to usage
