### PR TITLE
Install from Homebrew main tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Install the latest release from [Homebrew](https://brew.sh/), [Krew](https://git
 
 ```sh
 # Homebrew (macOS and Linux)
-brew install int128/kubelogin/kubelogin
+brew install kubelogin
 
 # Krew (macOS, Linux, Windows and ARM)
 kubectl krew install oidc-login


### PR DESCRIPTION
Since kubelogin exists in the homebrew main tap use that instead of third party tap.

Here is the formula: https://formulae.brew.sh/formula/kubelogin#default