### PR TITLE
Change default token cache storage to disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ If the refresh token has expired, it will perform re-authentication.
 
 ### Token cache
 
-If the OS keyring is available, kubelogin stores the token cache to the OS keyring.
-Otherwise, kubelogin stores the token cache to the file system.
+Kubelogin stores the token cache to the file system by default.
+It also supports the OS keyring for enhanced security.
 See the [token cache](docs/usage.md#token-cache) for details.
 
 You can log out by deleting the token cache.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ You can log out by deleting the token cache.
 ```console
 % kubectl oidc-login clean
 Deleted the token cache at /home/user/.kube/cache/oidc-login
+Deleted the token cache from the keyring
 ```
 
 Kubelogin will ask you to log in via the browser again.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If the refresh token has expired, it will perform re-authentication.
 ### Token cache
 
 Kubelogin stores the token cache to the file system by default.
-It also supports the OS keyring for enhanced security.
+For enhanced security, it is recommended to store it to the keyring.
 See the [token cache](docs/usage.md#token-cache) for details.
 
 You can log out by deleting the token cache.
@@ -92,7 +92,6 @@ You can log out by deleting the token cache.
 ```console
 % kubectl oidc-login clean
 Deleted the token cache at /home/user/.kube/cache/oidc-login
-Deleted the token cache in the keyring
 ```
 
 Kubelogin will ask you to log in via the browser again.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -203,7 +203,7 @@ Add `oidc` user to the kubeconfig.
 
 ```sh
 kubectl config set-credentials oidc \
-  --exec-interactive-mode=Never
+  --exec-interactive-mode=Never \
   --exec-api-version=client.authentication.k8s.io/v1 \
   --exec-command=kubectl \
   --exec-arg=oidc-login \
@@ -213,6 +213,9 @@ kubectl config set-credentials oidc \
 ```
 
 If your provider requires a client secret, add `--oidc-client-secret=YOUR_CLIENT_SECRET`.
+
+For security, it is recommended to add `--token-cache-storage=keyring` to store the token cache to the keyring instead of the file system.
+If you encounter an error, see the [token cache](usage.md#token-cache) for details.
 
 ## 6. Verify cluster access
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,7 +14,7 @@ Flags:
       --oidc-use-access-token                           Instead of using the id_token, use the access_token to authenticate to Kubernetes
       --force-refresh                                   If set, refresh the ID token regardless of its expiration time
       --token-cache-dir string                          Path to a directory of the token cache (default "~/.kube/cache/oidc-login")
-      --token-cache-storage string                      Storage for the token cache. One of (auto|keyring|disk) (default "auto")
+      --token-cache-storage string                      Storage for the token cache. One of (disk|keyring) (default "disk")
       --certificate-authority stringArray               Path to a cert file for the certificate authority
       --certificate-authority-data stringArray          Base64 encoded cert for the certificate authority
       --insecure-skip-tls-verify                        [SECURITY RISK] If set, the server's certificate will not be checked for validity
@@ -105,16 +105,13 @@ See also [net/http#ProxyFromEnvironment](https://golang.org/pkg/net/http/#ProxyF
 
 ### Token cache
 
-Kubelogin stores the token cache to the OS keyring if available.
-It depends on [zalando/go-keyring](https://github.com/zalando/go-keyring) for the keyring storage.
+Kubelogin stores the token cache to the file system by default.
 
-If you encounter a problem, try `--token-cache-storage` to set the storage.
+You can store the token cache to the OS keyring for enhanced security.
+It depends on [zalando/go-keyring](https://github.com/zalando/go-keyring).
 
 ```yaml
-# Force to use the OS keyring
 - --token-cache-storage=keyring
-# Force to use the file system
-- --token-cache-storage=disk
 ```
 
 ### Home directory expansion

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -114,13 +114,10 @@ It depends on [zalando/go-keyring](https://github.com/zalando/go-keyring).
 - --token-cache-storage=keyring
 ```
 
-You can clean up the token cache by the clean command.
+You can delete the token cache by the clean command.
 
 ```console
 % kubectl oidc-login clean
-Deleted the token cache at /home/user/.kube/cache/oidc-login
-
-% kubectl oidc-login clean --token-cache-storage=keyring
 Deleted the token cache at /home/user/.kube/cache/oidc-login
 Deleted the token cache from the keyring
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -114,6 +114,17 @@ It depends on [zalando/go-keyring](https://github.com/zalando/go-keyring).
 - --token-cache-storage=keyring
 ```
 
+You can clean up the token cache by the clean command.
+
+```console
+% kubectl oidc-login clean
+Deleted the token cache at /home/user/.kube/cache/oidc-login
+
+% kubectl oidc-login clean --token-cache-storage=keyring
+Deleted the token cache at /home/user/.kube/cache/oidc-login
+Deleted the token cache from the keyring
+```
+
 ### Home directory expansion
 
 If a value in the following options begins with a tilde character `~`, it is expanded to the home directory.

--- a/integration_test/clean_test.go
+++ b/integration_test/clean_test.go
@@ -20,7 +20,6 @@ func TestClean(t *testing.T) {
 		"kubelogin",
 		"clean",
 		"--token-cache-dir", tokenCacheDir,
-		"--token-cache-storage", "disk",
 	}, "HEAD")
 	if exitCode != 0 {
 		t.Errorf("exit status wants 0 but %d", exitCode)

--- a/integration_test/credetial_plugin_test.go
+++ b/integration_test/credetial_plugin_test.go
@@ -443,7 +443,6 @@ func runGetToken(t *testing.T, ctx context.Context, cfg getTokenConfig) {
 		"kubelogin",
 		"get-token",
 		"--token-cache-dir", cfg.tokenCacheDir,
-		"--token-cache-storage", "disk",
 		"--oidc-issuer-url", cfg.issuerURL,
 		"--oidc-client-id", "kubernetes",
 		"--listen-address", "127.0.0.1:0",

--- a/pkg/cmd/clean.go
+++ b/pkg/cmd/clean.go
@@ -31,8 +31,8 @@ func (cmd *Clean) New() *cobra.Command {
 		Short: "Delete the token cache",
 		Long: `Delete the token cache.
 
-This deletes both the OS keyring and the directory by default.
-If you encounter an error of keyring, try --token-cache-storage=disk.
+This deletes the token cache directory.
+Set --token-cache-storage=keyring to delete the token cache from the OS keyring as well.
 `,
 		Args: cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {

--- a/pkg/cmd/clean.go
+++ b/pkg/cmd/clean.go
@@ -9,15 +9,11 @@ import (
 )
 
 type cleanOptions struct {
-	tokenCacheOptions tokenCacheOptions
+	TokenCacheDir string
 }
 
 func (o *cleanOptions) addFlags(f *pflag.FlagSet) {
-	o.tokenCacheOptions.addFlags(f)
-}
-
-func (o *cleanOptions) expandHomedir() {
-	o.tokenCacheOptions.expandHomedir()
+	f.StringVar(&o.TokenCacheDir, "token-cache-dir", getDefaultTokenCacheDir(), "Path to a directory of the token cache")
 }
 
 type Clean struct {
@@ -31,18 +27,13 @@ func (cmd *Clean) New() *cobra.Command {
 		Short: "Delete the token cache",
 		Long: `Delete the token cache.
 
-This deletes the token cache directory.
-Set --token-cache-storage=keyring to delete the token cache from the OS keyring as well.
+This deletes the token cache directory from both the file system and the keyring.
 `,
 		Args: cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {
-			o.expandHomedir()
-			tokenCacheConfig, err := o.tokenCacheOptions.tokenCacheConfig()
-			if err != nil {
-				return fmt.Errorf("clean: %w", err)
-			}
+			o.TokenCacheDir = expandHomedir(o.TokenCacheDir)
 			in := clean.Input{
-				TokenCacheConfig: tokenCacheConfig,
+				TokenCacheDir: o.TokenCacheDir,
 			}
 			if err := cmd.Clean.Do(c.Context(), in); err != nil {
 				return fmt.Errorf("clean: %w", err)

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -118,7 +118,6 @@ func TestCmd_Run(t *testing.T) {
 					},
 					TokenCacheConfig: tokencache.Config{
 						Directory: filepath.Join(userHomeDir, ".kube/cache/oidc-login"),
-						Storage:   tokencache.StorageAuto,
 					},
 					GrantOptionSet: defaultGrantOptionSet,
 				},
@@ -131,7 +130,7 @@ func TestCmd_Run(t *testing.T) {
 					"--oidc-client-secret", "YOUR_CLIENT_SECRET",
 					"--oidc-extra-scope", "email",
 					"--oidc-extra-scope", "profile",
-					"--token-cache-storage", "disk",
+					"--token-cache-storage", "keyring",
 					"-v1",
 				},
 				in: credentialplugin.Input{
@@ -143,7 +142,7 @@ func TestCmd_Run(t *testing.T) {
 					},
 					TokenCacheConfig: tokencache.Config{
 						Directory: filepath.Join(userHomeDir, ".kube/cache/oidc-login"),
-						Storage:   tokencache.StorageDisk,
+						Storage:   tokencache.StorageKeyring,
 					},
 					GrantOptionSet: defaultGrantOptionSet,
 				},
@@ -163,7 +162,6 @@ func TestCmd_Run(t *testing.T) {
 					},
 					TokenCacheConfig: tokencache.Config{
 						Directory: filepath.Join(userHomeDir, ".kube/cache/oidc-login"),
-						Storage:   tokencache.StorageAuto,
 					},
 					GrantOptionSet: defaultGrantOptionSet,
 				},
@@ -185,7 +183,6 @@ func TestCmd_Run(t *testing.T) {
 					},
 					TokenCacheConfig: tokencache.Config{
 						Directory: filepath.Join(userHomeDir, ".kube/oidc-cache"),
-						Storage:   tokencache.StorageAuto,
 					},
 					GrantOptionSet: authentication.GrantOptionSet{
 						AuthCodeBrowserOption: &authcode.BrowserOption{

--- a/pkg/cmd/tokencache.go
+++ b/pkg/cmd/tokencache.go
@@ -18,7 +18,7 @@ func getDefaultTokenCacheDir() string {
 	return filepath.Join("~", ".kube", "cache", "oidc-login")
 }
 
-var allTokenCacheStorage = strings.Join([]string{"auto", "keyring", "disk"}, "|")
+var allTokenCacheStorage = strings.Join([]string{"disk", "keyring"}, "|")
 
 type tokenCacheOptions struct {
 	TokenCacheDir     string
@@ -27,7 +27,7 @@ type tokenCacheOptions struct {
 
 func (o *tokenCacheOptions) addFlags(f *pflag.FlagSet) {
 	f.StringVar(&o.TokenCacheDir, "token-cache-dir", getDefaultTokenCacheDir(), "Path to a directory of the token cache")
-	f.StringVar(&o.TokenCacheStorage, "token-cache-storage", "auto", fmt.Sprintf("Storage for the token cache. One of (%s)", allTokenCacheStorage))
+	f.StringVar(&o.TokenCacheStorage, "token-cache-storage", "disk", fmt.Sprintf("Storage for the token cache. One of (%s)", allTokenCacheStorage))
 }
 
 func (o *tokenCacheOptions) expandHomedir() {
@@ -39,12 +39,10 @@ func (o *tokenCacheOptions) tokenCacheConfig() (tokencache.Config, error) {
 		Directory: o.TokenCacheDir,
 	}
 	switch o.TokenCacheStorage {
-	case "auto":
-		config.Storage = tokencache.StorageAuto
-	case "keyring":
-		config.Storage = tokencache.StorageKeyring
 	case "disk":
 		config.Storage = tokencache.StorageDisk
+	case "keyring":
+		config.Storage = tokencache.StorageKeyring
 	default:
 		return tokencache.Config{}, fmt.Errorf("token-cache-storage must be one of (%s)", allTokenCacheStorage)
 	}

--- a/pkg/di/wire_gen.go
+++ b/pkg/di/wire_gen.go
@@ -97,9 +97,7 @@ func NewCmdForHeadless(clockInterface clock.Interface, stdin stdio.Stdin, stdout
 		Standalone: standaloneStandalone,
 		Logger:     loggerInterface,
 	}
-	repositoryRepository := &repository.Repository{
-		Logger: loggerInterface,
-	}
+	repositoryRepository := &repository.Repository{}
 	reader3 := &reader2.Reader{}
 	writer3 := &writer2.Writer{
 		Stdout: stdout,

--- a/pkg/tokencache/types.go
+++ b/pkg/tokencache/types.go
@@ -25,10 +25,8 @@ type Config struct {
 type Storage byte
 
 const (
-	// StorageAuto will prefer keyring when available, and fallback to disk when not.
-	StorageAuto Storage = iota
 	// StorageDisk will only store cached keys on disk.
-	StorageDisk
+	StorageDisk Storage = iota
 	// StorageDisk will only store cached keys in the OS keyring.
 	StorageKeyring
 )

--- a/system_test/login/Makefile
+++ b/system_test/login/Makefile
@@ -15,7 +15,6 @@ test: build
 		--oidc-client-id=YOUR_CLIENT_ID \
 		--oidc-client-secret=YOUR_CLIENT_SECRET \
 		--oidc-extra-scope=email \
-		--token-cache-storage=keyring \
 		--certificate-authority=$(CERT_DIR)/ca.crt \
 		--browser-command=$(BIN_DIR)/chromelogin
 

--- a/system_test/login/Makefile
+++ b/system_test/login/Makefile
@@ -15,6 +15,7 @@ test: build
 		--oidc-client-id=YOUR_CLIENT_ID \
 		--oidc-client-secret=YOUR_CLIENT_SECRET \
 		--oidc-extra-scope=email \
+		--token-cache-storage=keyring \
 		--certificate-authority=$(CERT_DIR)/ca.crt \
 		--browser-command=$(BIN_DIR)/chromelogin
 
@@ -29,6 +30,7 @@ test: build
 		--exec-arg=--oidc-client-id=YOUR_CLIENT_ID \
 		--exec-arg=--oidc-client-secret=YOUR_CLIENT_SECRET \
 		--exec-arg=--oidc-extra-scope=email \
+		--exec-arg=--token-cache-storage=keyring \
 		--exec-arg=--certificate-authority=$(CERT_DIR)/ca.crt \
 		--exec-arg=--browser-command=$(BIN_DIR)/chromelogin
 


### PR DESCRIPTION
See https://github.com/int128/kubelogin/issues/1255#issuecomment-2613822496.

## Changes
It changes the default value of token cache storage to `disk`. It also adds the recommendation usage to docs.

It removes `--token-cache-storage` flag from clean command. Instead, clean command deletes both the file system and keyring.
