### PR TITLE
Provide a token-cache-storage type of none

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,7 +14,7 @@ Flags:
       --oidc-use-access-token                           Instead of using the id_token, use the access_token to authenticate to Kubernetes
       --force-refresh                                   If set, refresh the ID token regardless of its expiration time
       --token-cache-dir string                          Path to a directory of the token cache (default "~/.kube/cache/oidc-login")
-      --token-cache-storage string                      Storage for the token cache. One of (disk|keyring) (default "disk")
+      --token-cache-storage string                      Storage for the token cache. One of (disk|keyring|none) (default "disk")
       --certificate-authority stringArray               Path to a cert file for the certificate authority
       --certificate-authority-data stringArray          Base64 encoded cert for the certificate authority
       --insecure-skip-tls-verify                        [SECURITY RISK] If set, the server's certificate will not be checked for validity
@@ -121,6 +121,8 @@ You can delete the token cache by the clean command.
 Deleted the token cache at /home/user/.kube/cache/oidc-login
 Deleted the token cache from the keyring
 ```
+
+For systems with immutable storage and no keyring, a cache type of none is available.
 
 ### Home directory expansion
 

--- a/pkg/cmd/tokencache.go
+++ b/pkg/cmd/tokencache.go
@@ -18,7 +18,7 @@ func getDefaultTokenCacheDir() string {
 	return filepath.Join("~", ".kube", "cache", "oidc-login")
 }
 
-var allTokenCacheStorage = strings.Join([]string{"disk", "keyring"}, "|")
+var allTokenCacheStorage = strings.Join([]string{"disk", "keyring", "none"}, "|")
 
 type tokenCacheOptions struct {
 	TokenCacheDir     string
@@ -43,6 +43,8 @@ func (o *tokenCacheOptions) tokenCacheConfig() (tokencache.Config, error) {
 		config.Storage = tokencache.StorageDisk
 	case "keyring":
 		config.Storage = tokencache.StorageKeyring
+	case "none":
+		config.Storage = tokencache.StorageNone
 	default:
 		return tokencache.Config{}, fmt.Errorf("token-cache-storage must be one of (%s)", allTokenCacheStorage)
 	}

--- a/pkg/tokencache/types.go
+++ b/pkg/tokencache/types.go
@@ -29,4 +29,6 @@ const (
 	StorageDisk Storage = iota
 	// StorageDisk will only store cached keys in the OS keyring.
 	StorageKeyring
+	// StorageNone will not store cached keys.
+	StorageNone
 )


### PR DESCRIPTION
When running in a container, the system often has no keyring service and may not offer a writeable directory. Instead of writing to ramdisk for cache, this pull request offers a none type for the cache.