### PR TITLE
Add option to print QR code for device-code flow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/int128/oauth2cli v1.15.1
 	github.com/int128/oauth2dev v1.0.1
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
+	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -583,6 +583,8 @@ github.com/sivchari/containedctx v1.0.3 h1:x+etemjbsh2fB5ewm5FeLNi5bUjK0V8n0RB+W
 github.com/sivchari/containedctx v1.0.3/go.mod h1:c1RDvCbnJLtH4lLcYD/GqwiBSSf4F5Qk0xld2rBqzJ4=
 github.com/sivchari/tenv v1.12.1 h1:+E0QzjktdnExv/wwsnnyk4oqZBUfuh89YMQT1cyuvSY=
 github.com/sivchari/tenv v1.12.1/go.mod h1:1LjSOUCc25snIr5n3DtGGrENhX3LuWefcplwVGC24mw=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/sonatard/noctx v0.1.0 h1:JjqOc2WN16ISWAjAk8M5ej0RfExEXtkEyExl2hLW+OM=
 github.com/sonatard/noctx v0.1.0/go.mod h1:0RvBxqY8D4j9cTTTWE8ylt2vqj2EPI8fHmrxHdsaZ2c=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=

--- a/pkg/cmd/authentication.go
+++ b/pkg/cmd/authentication.go
@@ -28,6 +28,7 @@ type authenticationOptions struct {
 	AuthRequestExtraParams      map[string]string
 	Username                    string
 	Password                    string
+	GenerateQRCode              bool
 }
 
 var allGrantType = strings.Join([]string{
@@ -52,6 +53,7 @@ func (o *authenticationOptions) addFlags(f *pflag.FlagSet) {
 	f.StringToStringVar(&o.AuthRequestExtraParams, "oidc-auth-request-extra-params", nil, "[authcode, authcode-keyboard] Extra query parameters to send with an authentication request")
 	f.StringVar(&o.Username, "username", "", "[password] Username for resource owner password credentials grant")
 	f.StringVar(&o.Password, "password", "", "[password] Password for resource owner password credentials grant")
+	f.BoolVar(&o.GenerateQRCode, "generate-qrcode", false, "[device-code] Generate a QR code for authentication")
 }
 
 func (o *authenticationOptions) expandHomedir() {
@@ -87,6 +89,7 @@ func (o *authenticationOptions) grantOptionSet() (s authentication.GrantOptionSe
 		s.DeviceCodeOption = &devicecode.Option{
 			SkipOpenBrowser: o.SkipOpenBrowser,
 			BrowserCommand:  o.BrowserCommand,
+			GenerateQRCode:  o.GenerateQRCode,
 		}
 	default:
 		err = fmt.Errorf("grant-type must be one of (%s)", allGrantType)


### PR DESCRIPTION
Adds an option to print a QR code on the terminal for device-code flow. Allows to scan quickly by mobile phone