### PR TITLE
Add --browser-args option

### DIFF
--- a/integration_test/httpdriver/http_driver.go
+++ b/integration_test/httpdriver/http_driver.go
@@ -64,7 +64,7 @@ func (c *client) Open(url string) error {
 	return nil
 }
 
-func (c *client) OpenCommand(_ context.Context, url, _ string) error {
+func (c *client) OpenCommand(_ context.Context, _ string, _ []string, url string) error {
 	return c.Open(url)
 }
 
@@ -77,6 +77,6 @@ func (c *zeroClient) Open(url string) error {
 	return nil
 }
 
-func (c *zeroClient) OpenCommand(_ context.Context, url, _ string) error {
+func (c *zeroClient) OpenCommand(_ context.Context, _ string, _ []string, url string) error {
 	return c.Open(url)
 }

--- a/mocks/github.com/int128/kubelogin/pkg/infrastructure/browser_mock/mocks.go
+++ b/mocks/github.com/int128/kubelogin/pkg/infrastructure/browser_mock/mocks.go
@@ -89,16 +89,16 @@ func (_c *MockInterface_Open_Call) RunAndReturn(run func(url string) error) *Moc
 }
 
 // OpenCommand provides a mock function for the type MockInterface
-func (_mock *MockInterface) OpenCommand(ctx context.Context, url string, command string) error {
-	ret := _mock.Called(ctx, url, command)
+func (_mock *MockInterface) OpenCommand(ctx context.Context, command string, args []string, url string) error {
+	ret := _mock.Called(ctx, command, args, url)
 
 	if len(ret) == 0 {
 		panic("no return value specified for OpenCommand")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
-		r0 = returnFunc(ctx, url, command)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string, string) error); ok {
+		r0 = returnFunc(ctx, command, args, url)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -112,13 +112,14 @@ type MockInterface_OpenCommand_Call struct {
 
 // OpenCommand is a helper method to define mock.On call
 //   - ctx context.Context
-//   - url string
 //   - command string
-func (_e *MockInterface_Expecter) OpenCommand(ctx interface{}, url interface{}, command interface{}) *MockInterface_OpenCommand_Call {
-	return &MockInterface_OpenCommand_Call{Call: _e.mock.On("OpenCommand", ctx, url, command)}
+//   - args []string
+//   - url string
+func (_e *MockInterface_Expecter) OpenCommand(ctx interface{}, command interface{}, args interface{}, url interface{}) *MockInterface_OpenCommand_Call {
+	return &MockInterface_OpenCommand_Call{Call: _e.mock.On("OpenCommand", ctx, command, args, url)}
 }
 
-func (_c *MockInterface_OpenCommand_Call) Run(run func(ctx context.Context, url string, command string)) *MockInterface_OpenCommand_Call {
+func (_c *MockInterface_OpenCommand_Call) Run(run func(ctx context.Context, command string, args []string, url string)) *MockInterface_OpenCommand_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -128,14 +129,19 @@ func (_c *MockInterface_OpenCommand_Call) Run(run func(ctx context.Context, url 
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 string
+		var arg2 []string
 		if args[2] != nil {
-			arg2 = args[2].(string)
+			arg2 = args[2].([]string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -146,7 +152,7 @@ func (_c *MockInterface_OpenCommand_Call) Return(err error) *MockInterface_OpenC
 	return _c
 }
 
-func (_c *MockInterface_OpenCommand_Call) RunAndReturn(run func(ctx context.Context, url string, command string) error) *MockInterface_OpenCommand_Call {
+func (_c *MockInterface_OpenCommand_Call) RunAndReturn(run func(ctx context.Context, command string, args []string, url string) error) *MockInterface_OpenCommand_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/cmd/authentication.go
+++ b/pkg/cmd/authentication.go
@@ -20,6 +20,7 @@ type authenticationOptions struct {
 	AuthenticationTimeoutSec    int
 	SkipOpenBrowser             bool
 	BrowserCommand              string
+	BrowserArgs                 []string
 	LocalServerCertFile         string
 	LocalServerKeyFile          string
 	OpenURLAfterAuthentication  string
@@ -43,6 +44,7 @@ func (o *authenticationOptions) addFlags(f *pflag.FlagSet) {
 	f.StringSliceVar(&o.ListenAddress, "listen-address", defaultListenAddress, "[authcode] Address to bind to the local server. If multiple addresses are set, it will try binding in order")
 	f.BoolVar(&o.SkipOpenBrowser, "skip-open-browser", false, "[authcode] Do not open the browser automatically")
 	f.StringVar(&o.BrowserCommand, "browser-command", "", "[authcode] Command to open the browser")
+	f.StringSliceVar(&o.BrowserArgs, "browser-args", nil, "[authcode] Command arguments to use when openning the browser")
 	f.IntVar(&o.AuthenticationTimeoutSec, "authentication-timeout-sec", defaultAuthenticationTimeoutSec, "[authcode] Timeout of authentication in seconds")
 	f.StringVar(&o.LocalServerCertFile, "local-server-cert", "", "[authcode] Certificate path for the local server")
 	f.StringVar(&o.LocalServerKeyFile, "local-server-key", "", "[authcode] Certificate key path for the local server")
@@ -66,6 +68,7 @@ func (o *authenticationOptions) grantOptionSet() (s authentication.GrantOptionSe
 			BindAddress:                o.ListenAddress,
 			SkipOpenBrowser:            o.SkipOpenBrowser,
 			BrowserCommand:             o.BrowserCommand,
+			BrowserArgs:                o.BrowserArgs,
 			AuthenticationTimeout:      time.Duration(o.AuthenticationTimeoutSec) * time.Second,
 			LocalServerCertFile:        o.LocalServerCertFile,
 			LocalServerKeyFile:         o.LocalServerKeyFile,

--- a/pkg/infrastructure/browser/browser.go
+++ b/pkg/infrastructure/browser/browser.go
@@ -23,7 +23,7 @@ var Set = wire.NewSet(
 
 type Interface interface {
 	Open(url string) error
-	OpenCommand(ctx context.Context, url, command string) error
+	OpenCommand(ctx context.Context, command string, args []string, url string) error
 }
 
 type Browser struct{}
@@ -34,8 +34,9 @@ func (*Browser) Open(url string) error {
 }
 
 // OpenCommand opens the browser using the command.
-func (*Browser) OpenCommand(ctx context.Context, url, command string) error {
-	c := exec.CommandContext(ctx, command, url)
+func (*Browser) OpenCommand(ctx context.Context, command string, args []string, url string) error {
+	args = append(args, url)
+	c := exec.CommandContext(ctx, command, args...)
 	c.Stdout = os.Stderr // see above
 	c.Stderr = os.Stderr
 	return c.Run()

--- a/pkg/usecases/authentication/authcode/browser.go
+++ b/pkg/usecases/authentication/authcode/browser.go
@@ -16,6 +16,7 @@ import (
 type BrowserOption struct {
 	SkipOpenBrowser            bool
 	BrowserCommand             string
+	BrowserArgs                []string
 	BindAddress                []string
 	AuthenticationTimeout      time.Duration
 	OpenURLAfterAuthentication string
@@ -103,7 +104,7 @@ func (u *Browser) openURL(ctx context.Context, o *BrowserOption, url string) {
 
 	u.Logger.V(1).Infof("opening %s in the browser", url)
 	if o.BrowserCommand != "" {
-		if err := u.Browser.OpenCommand(ctx, url, o.BrowserCommand); err != nil {
+		if err := u.Browser.OpenCommand(ctx, o.BrowserCommand, o.BrowserArgs, url); err != nil {
 			u.Logger.Printf(`error: could not open the browser: %s
 
 Please visit the following URL in your browser manually: %s`, err, url)

--- a/pkg/usecases/authentication/devicecode/devicecode.go
+++ b/pkg/usecases/authentication/devicecode/devicecode.go
@@ -13,6 +13,7 @@ import (
 type Option struct {
 	SkipOpenBrowser bool
 	BrowserCommand  string
+	BrowserArgs     []string
 }
 
 // DeviceCode provides the oauth2 device code flow.
@@ -57,7 +58,7 @@ func (u *DeviceCode) openURL(ctx context.Context, o *Option, url string) {
 
 	u.Logger.V(1).Infof("opening %s in the browser", url)
 	if o != nil && o.BrowserCommand != "" {
-		if err := u.Browser.OpenCommand(ctx, url, o.BrowserCommand); err != nil {
+		if err := u.Browser.OpenCommand(ctx, o.BrowserCommand, o.BrowserArgs, url); err != nil {
 			u.Logger.Printf(`error: could not open the browser: %s
 
 Please visit the following URL in your browser manually: %s`, err, url)

--- a/pkg/usecases/authentication/devicecode/devicecode_test.go
+++ b/pkg/usecases/authentication/devicecode/devicecode_test.go
@@ -179,7 +179,17 @@ func TestDeviceCode_openURL(t *testing.T) {
 			Browser: browserMock,
 			Logger:  logger.New(t),
 		}
-		browserMock.EXPECT().OpenCommand(ctx, url, "test-command").Return(testError).Once()
+		browserMock.EXPECT().OpenCommand(ctx, "test-command", []string(nil), url).Return(testError).Once()
 		deviceCode.openURL(ctx, &Option{BrowserCommand: "test-command"}, url)
+	})
+
+	t.Run("BrowserCommand and BrowserArgs are set", func(t *testing.T) {
+		browserMock := browser_mock.NewMockInterface(t)
+		deviceCode := &DeviceCode{
+			Browser: browserMock,
+			Logger:  logger.New(t),
+		}
+		browserMock.EXPECT().OpenCommand(ctx, "test-command", []string{"arg1", "arg2"}, url).Return(testError).Once()
+		deviceCode.openURL(ctx, &Option{BrowserCommand: "test-command", BrowserArgs: []string{"arg1", "arg2"}}, url)
 	})
 }


### PR DESCRIPTION
This change adds the --browser-args option, which takes a slice of strings. These arguments will be passed to the browser command specified with --browser-command. This allows for prepending arguments before the URL.

The primary use case for this feature is to allow opening a browser without needing to make an alias or script to add arguments. For example, "powershell.exe start $URL" allows opening a browser in WSL without needing to access the registry to read the default browser.

On Windows machines with registry access restricted, `kubectl oidc-login get-token` errors with the error:
`ERROR: Registry editing has been disabled by your administrator.`. This happens because `x-www-browser`, an alias to `wslview`, tries to use `reg.exe` to read the default browser from the registry.

To work around this error, with this PR, you can configure `--browser-command=powershell.exe` and `--browser-args=start` to bypass `wslview` and launch the browser directly without error.

Note: Some sources say you can use `explorer.exe $URL` to open a browser, but this always returns error code 1, due to a long standing bug: https://github.com/microsoft/WSL/issues/6565