### PR TITLE
Use Endpoint.DeviceAuthURL of oauth2 package

### DIFF
--- a/pkg/oidc/client/client.go
+++ b/pkg/oidc/client/client.go
@@ -28,14 +28,13 @@ type Interface interface {
 }
 
 type client struct {
-	httpClient                  *http.Client
-	provider                    *gooidc.Provider
-	oauth2Config                oauth2.Config
-	clock                       clock.Interface
-	logger                      logger.Interface
-	negotiatedPKCEMethod        pkce.Method
-	deviceAuthorizationEndpoint string
-	useAccessToken              bool
+	httpClient           *http.Client
+	provider             *gooidc.Provider
+	oauth2Config         oauth2.Config
+	clock                clock.Interface
+	logger               logger.Interface
+	negotiatedPKCEMethod pkce.Method
+	useAccessToken       bool
 }
 
 func (c *client) wrapContext(ctx context.Context) context.Context {

--- a/pkg/oidc/client/devicecode.go
+++ b/pkg/oidc/client/devicecode.go
@@ -14,7 +14,7 @@ func (c *client) GetDeviceAuthorization(ctx context.Context) (*oauth2dev.Authori
 	ctx = c.wrapContext(ctx)
 	config := c.oauth2Config
 	config.Endpoint = oauth2.Endpoint{
-		AuthURL: c.deviceAuthorizationEndpoint,
+		AuthURL: c.provider.Endpoint().DeviceAuthURL,
 	}
 	return oauth2dev.RetrieveCode(ctx, config)
 }


### PR DESCRIPTION
Use the parser implementation at https://github.com/coreos/go-oidc/blob/a7c457eacb849c163a496b29274242474a8f44ab/oidc/oidc.go#L192-L194 instead.
