### PR TITLE
Allow use of $BROWSER env variable for browser-command

### DIFF
--- a/pkg/cmd/authentication.go
+++ b/pkg/cmd/authentication.go
@@ -43,7 +43,7 @@ func (o *authenticationOptions) addFlags(f *pflag.FlagSet) {
 	f.StringVar(&o.GrantType, "grant-type", "auto", fmt.Sprintf("Authorization grant type to use. One of (%s)", allGrantType))
 	f.StringSliceVar(&o.ListenAddress, "listen-address", defaultListenAddress, "[authcode] Address to bind to the local server. If multiple addresses are set, it will try binding in order")
 	f.BoolVar(&o.SkipOpenBrowser, "skip-open-browser", false, "[authcode] Do not open the browser automatically")
-	f.StringVar(&o.BrowserCommand, "browser-command", "", "[authcode] Command to open the browser")
+	f.StringVar(&o.BrowserCommand, "browser-command", os.Getenv("BROWSER"), "[authcode] Command to open the browser")
 	f.IntVar(&o.AuthenticationTimeoutSec, "authentication-timeout-sec", defaultAuthenticationTimeoutSec, "[authcode] Timeout of authentication in seconds")
 	f.StringVar(&o.LocalServerCertFile, "local-server-cert", "", "[authcode] Certificate path for the local server")
 	f.StringVar(&o.LocalServerKeyFile, "local-server-key", "", "[authcode] Certificate key path for the local server")


### PR DESCRIPTION
This environment variable is standard and used in few other projects and is handy to let the user run kubelogin in many different environments

Defaults to empty string (previous) behaviour if not defined. and the default value is displayed to the user when running `kubectl oidc-login get-token --help` so it's not obscured away