### PR TITLE
feat: add implicit flow support

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -23,15 +23,15 @@ Flags:
       --tls-renegotiation-once                          If set, allow a remote server to request renegotiation once per connection
       --tls-renegotiation-freely                        If set, allow a remote server to repeatedly request renegotiation
       --oidc-pkce-method string                         PKCE code challenge method. Automatically determined by default. One of (auto|no|S256) (default "auto")
-      --grant-type string                               Authorization grant type to use. One of (auto|authcode|authcode-keyboard|password|device-code|client-credentials) (default "auto")
-      --listen-address strings                          [authcode] Address to bind to the local server. If multiple addresses are set, it will try binding in order (default [127.0.0.1:8000,127.0.0.1:18000])
-      --skip-open-browser                               [authcode] Do not open the browser automatically
-      --browser-command string                          [authcode] Command to open the browser
-      --authentication-timeout-sec int                  [authcode] Timeout of authentication in seconds (default 180)
-      --local-server-cert string                        [authcode] Certificate path for the local server
-      --local-server-key string                         [authcode] Certificate key path for the local server
-      --open-url-after-authentication string            [authcode] If set, open the URL in the browser after authentication
-      --oidc-auth-request-extra-params stringToString   [authcode, authcode-keyboard, client-credentials] Extra query parameters to send with an authentication request (default [])
+      --grant-type string                               Authorization grant type to use. One of (auto|authcode|authcode-keyboard|implicit|password|device-code|client-credentials) (default "auto")
+      --listen-address strings                          [authcode, implicit] Address to bind to the local server. If multiple addresses are set, it will try binding in order (default [127.0.0.1:8000,127.0.0.1:18000])
+      --skip-open-browser                               [authcode, implicit] Do not open the browser automatically
+      --browser-command string                          [authcode, implicit] Command to open the browser
+      --authentication-timeout-sec int                  [authcode, implicit] Timeout of authentication in seconds (default 180)
+      --local-server-cert string                        [authcode, implicit] Certificate path for the local server
+      --local-server-key string                         [authcode, implicit] Certificate key path for the local server
+      --open-url-after-authentication string            [authcode, implicit] If set, open the URL in the browser after authentication
+      --oidc-auth-request-extra-params stringToString   [authcode, authcode-keyboard, implicit, client-credentials] Extra query parameters to send with an authentication request (default [])
       --username string                                 [password] Username for resource owner password credentials grant
       --password string                                 [password] Password for resource owner password credentials grant
   -h, --help                                            help for get-token
@@ -150,6 +150,7 @@ Kubelogin support the following flows:
 - [Device Authorization Grant](#device-authorization-grant)
 - [Authorization Code Flow](#authorization-code-flow)
 - [Authorization Code Flow with a Keyboard](#authorization-code-flow-with-a-keyboard)
+- [Implicit Flow](#implicit-flow)
 - [Resource Owner Password Credentials Grant](#resource-owner-password-credentials-grant)
 - [Client Credentials Flow](#client-credentials-flow)
 
@@ -257,6 +258,27 @@ You can add extra parameters to the authentication request.
 ```yaml
 - --oidc-auth-request-extra-params=ttl=86400
 ```
+
+### Implicit Flow
+
+The implicit flow is used when it is desired that the ID token contain claims for the requests scopes. One use for this would be to allow role bindings to be based off a user's groups.
+
+It should be noted that the Implicit Flow is deprecated by the OpenID Foundation.
+
+It performs the [Implicit Flow](https://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth) when `--grant-type=implicit` is set.
+
+```yaml
+- --grant-type=implicit
+```
+
+The implicit flow returns only an ID token without an access token or refresh token.
+This flow is useful when you want to:
+- Avoid minting unused access tokens
+- Request specific claims be included in the ID token
+- Enforce shorter credential lifetimes (no refresh tokens)
+
+Note that the implicit flow does not support refresh tokens.
+You will need to re-authenticate when the ID token expires.
 
 ### Resource Owner Password Credentials Grant
 

--- a/mocks/github.com/int128/kubelogin/pkg/oidc/client_mock/mocks.go
+++ b/mocks/github.com/int128/kubelogin/pkg/oidc/client_mock/mocks.go
@@ -433,6 +433,80 @@ func (_c *MockInterface_GetTokenByClientCredentials_Call) RunAndReturn(run func(
 	return _c
 }
 
+// GetTokenByImplicitFlow provides a mock function for the type MockInterface
+func (_mock *MockInterface) GetTokenByImplicitFlow(ctx context.Context, in client.GetTokenByImplicitFlowInput, localServerReadyChan chan<- string) (*oidc.TokenSet, error) {
+	ret := _mock.Called(ctx, in, localServerReadyChan)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTokenByImplicitFlow")
+	}
+
+	var r0 *oidc.TokenSet
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, client.GetTokenByImplicitFlowInput, chan<- string) (*oidc.TokenSet, error)); ok {
+		return returnFunc(ctx, in, localServerReadyChan)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, client.GetTokenByImplicitFlowInput, chan<- string) *oidc.TokenSet); ok {
+		r0 = returnFunc(ctx, in, localServerReadyChan)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*oidc.TokenSet)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, client.GetTokenByImplicitFlowInput, chan<- string) error); ok {
+		r1 = returnFunc(ctx, in, localServerReadyChan)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockInterface_GetTokenByImplicitFlow_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTokenByImplicitFlow'
+type MockInterface_GetTokenByImplicitFlow_Call struct {
+	*mock.Call
+}
+
+// GetTokenByImplicitFlow is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in client.GetTokenByImplicitFlowInput
+//   - localServerReadyChan chan<- string
+func (_e *MockInterface_Expecter) GetTokenByImplicitFlow(ctx interface{}, in interface{}, localServerReadyChan interface{}) *MockInterface_GetTokenByImplicitFlow_Call {
+	return &MockInterface_GetTokenByImplicitFlow_Call{Call: _e.mock.On("GetTokenByImplicitFlow", ctx, in, localServerReadyChan)}
+}
+
+func (_c *MockInterface_GetTokenByImplicitFlow_Call) Run(run func(ctx context.Context, in client.GetTokenByImplicitFlowInput, localServerReadyChan chan<- string)) *MockInterface_GetTokenByImplicitFlow_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 client.GetTokenByImplicitFlowInput
+		if args[1] != nil {
+			arg1 = args[1].(client.GetTokenByImplicitFlowInput)
+		}
+		var arg2 chan<- string
+		if args[2] != nil {
+			arg2 = args[2].(chan<- string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockInterface_GetTokenByImplicitFlow_Call) Return(tokenSet *oidc.TokenSet, err error) *MockInterface_GetTokenByImplicitFlow_Call {
+	_c.Call.Return(tokenSet, err)
+	return _c
+}
+
+func (_c *MockInterface_GetTokenByImplicitFlow_Call) RunAndReturn(run func(ctx context.Context, in client.GetTokenByImplicitFlowInput, localServerReadyChan chan<- string) (*oidc.TokenSet, error)) *MockInterface_GetTokenByImplicitFlow_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetTokenByROPC provides a mock function for the type MockInterface
 func (_mock *MockInterface) GetTokenByROPC(ctx context.Context, username string, password string) (*oidc.TokenSet, error) {
 	ret := _mock.Called(ctx, username, password)

--- a/pkg/di/wire_gen.go
+++ b/pkg/di/wire_gen.go
@@ -24,6 +24,7 @@ import (
 	"github.com/int128/kubelogin/pkg/usecases/authentication/authcode"
 	"github.com/int128/kubelogin/pkg/usecases/authentication/clientcredentials"
 	"github.com/int128/kubelogin/pkg/usecases/authentication/devicecode"
+	"github.com/int128/kubelogin/pkg/usecases/authentication/implicit"
 	"github.com/int128/kubelogin/pkg/usecases/authentication/ropc"
 	"github.com/int128/kubelogin/pkg/usecases/clean"
 	"github.com/int128/kubelogin/pkg/usecases/credentialplugin"
@@ -69,6 +70,10 @@ func NewCmdForHeadless(clockInterface clock.Interface, stdin stdio.Stdin, stdout
 		Reader: readerReader,
 		Logger: loggerInterface,
 	}
+	implicitBrowser := &implicit.Browser{
+		Browser: browserInterface,
+		Logger:  loggerInterface,
+	}
 	ropcROPC := &ropc.ROPC{
 		Reader: readerReader,
 		Logger: loggerInterface,
@@ -85,6 +90,7 @@ func NewCmdForHeadless(clockInterface clock.Interface, stdin stdio.Stdin, stdout
 		Logger:            loggerInterface,
 		AuthCodeBrowser:   authcodeBrowser,
 		AuthCodeKeyboard:  keyboard,
+		ImplicitBrowser:   implicitBrowser,
 		ROPC:              ropcROPC,
 		DeviceCode:        deviceCode,
 		ClientCredentials: clientCredentials,

--- a/pkg/oidc/client/client.go
+++ b/pkg/oidc/client/client.go
@@ -19,6 +19,7 @@ type Interface interface {
 	GetAuthCodeURL(in AuthCodeURLInput) string
 	ExchangeAuthCode(ctx context.Context, in ExchangeAuthCodeInput) (*oidc.TokenSet, error)
 	GetTokenByAuthCode(ctx context.Context, in GetTokenByAuthCodeInput, localServerReadyChan chan<- string) (*oidc.TokenSet, error)
+	GetTokenByImplicitFlow(ctx context.Context, in GetTokenByImplicitFlowInput, localServerReadyChan chan<- string) (*oidc.TokenSet, error)
 	NegotiatedPKCEMethod() pkce.Method
 	GetTokenByROPC(ctx context.Context, username, password string) (*oidc.TokenSet, error)
 	GetTokenByClientCredentials(ctx context.Context, in GetTokenByClientCredentialsInput) (*oidc.TokenSet, error)

--- a/pkg/oidc/client/implicit.go
+++ b/pkg/oidc/client/implicit.go
@@ -1,0 +1,258 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/int128/kubelogin/pkg/oidc"
+	"golang.org/x/oauth2"
+)
+
+type GetTokenByImplicitFlowInput struct {
+	BindAddress            []string
+	State                  string
+	Nonce                  string
+	AuthRequestExtraParams map[string]string
+	LocalServerSuccessHTML string
+	LocalServerCertFile    string
+	LocalServerKeyFile     string
+}
+
+// GetTokenByImplicitFlow performs the implicit flow with id_token
+func (c *client) GetTokenByImplicitFlow(ctx context.Context, in GetTokenByImplicitFlowInput, localServerReadyChan chan<- string) (*oidc.TokenSet, error) {
+	ctx = c.wrapContext(ctx)
+
+	tokenChan := make(chan map[string]string, 1)
+	errChan := make(chan error, 1)
+
+	server, serverURL, err := c.startImplicitFlowServer(ctx, in, tokenChan, errChan)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start local server: %w", err)
+	}
+	defer func() {
+		_ = server.Shutdown(context.Background())
+	}()
+
+	authURL := c.buildImplicitFlowAuthURL(serverURL, in.State, in.Nonce, in.AuthRequestExtraParams)
+
+	if localServerReadyChan != nil {
+		c.logger.V(1).Infof("Local server ready at %s", serverURL)
+		c.logger.V(1).Infof("Authorization URL: %s", authURL)
+		localServerReadyChan <- authURL
+	}
+
+	select {
+	case tokens := <-tokenChan:
+		return c.processImplicitFlowTokens(ctx, tokens, in.State, in.Nonce)
+	case err := <-errChan:
+		return nil, err
+	case <-ctx.Done():
+		return nil, fmt.Errorf("context cancelled: %w", ctx.Err())
+	}
+}
+
+// buildImplicitFlowAuthURL creates the authorization URL for implicit flow
+func (c *client) buildImplicitFlowAuthURL(redirectURI, state, nonce string, extraParams map[string]string) string {
+	params := url.Values{}
+	params.Set("client_id", c.oauth2Config.ClientID)
+	params.Set("redirect_uri", redirectURI)
+	params.Set("response_type", "id_token")
+
+	scopes := append([]string{"openid"}, c.oauth2Config.Scopes...)
+	params.Set("scope", strings.Join(scopes, " "))
+
+	params.Set("state", state)
+	params.Set("nonce", nonce)
+	params.Set("response_mode", "fragment")
+
+	for key, value := range extraParams {
+		params.Set(key, value)
+	}
+
+	return c.oauth2Config.Endpoint.AuthURL + "?" + params.Encode()
+}
+
+// startImplicitFlowServer starts a local HTTP server to capture the implicit flow redirect
+func (c *client) startImplicitFlowServer(ctx context.Context, in GetTokenByImplicitFlowInput, tokenChan chan<- map[string]string, errChan chan<- error) (*http.Server, string, error) {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		html := c.getFragmentExtractorHTML(in.LocalServerSuccessHTML)
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(html))
+	})
+
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		if err := r.ParseForm(); err != nil {
+			errChan <- fmt.Errorf("failed to parse form: %w", err)
+			http.Error(w, "Bad request", http.StatusBadRequest)
+			return
+		}
+
+		tokens := map[string]string{
+			"id_token":          r.FormValue("id_token"),
+			"state":             r.FormValue("state"),
+			"error":             r.FormValue("error"),
+			"error_description": r.FormValue("error_description"),
+		}
+
+		if tokens["error"] != "" {
+			errChan <- fmt.Errorf("authorization error: %s - %s", tokens["error"], tokens["error_description"])
+			http.Error(w, "Authorization failed", http.StatusBadRequest)
+			return
+		}
+
+		tokenChan <- tokens
+
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte("OK"))
+		if err != nil {
+			return
+		}
+	})
+
+	var server *http.Server
+	var serverURL string
+	var lastErr error
+
+	for _, addr := range in.BindAddress {
+		server = &http.Server{
+			Addr:    addr,
+			Handler: mux,
+		}
+
+		go func() {
+			var err error
+			if in.LocalServerCertFile != "" && in.LocalServerKeyFile != "" {
+				err = server.ListenAndServeTLS(in.LocalServerCertFile, in.LocalServerKeyFile)
+			} else {
+				err = server.ListenAndServe()
+			}
+			if err != nil && !errors.Is(err, http.ErrServerClosed) {
+				c.logger.V(1).Infof("Server error: %v", err)
+			}
+		}()
+
+		time.Sleep(100 * time.Millisecond)
+
+		scheme := "http"
+		if in.LocalServerCertFile != "" {
+			scheme = "https"
+		}
+		serverURL = fmt.Sprintf("%s://%s", scheme, addr)
+
+		c.logger.V(1).Infof("Started server on %s", serverURL)
+		return server, serverURL, nil
+	}
+
+	return nil, "", fmt.Errorf("failed to start server on any address: %w", lastErr)
+}
+
+// getFragmentExtractorHTML returns HTML with JavaScript to extract tokens from URL fragment and send it to the backend.
+func (c *client) getFragmentExtractorHTML(successHTML string) string {
+	if successHTML != "" {
+		return fmt.Sprintf(`<!DOCTYPE html>
+<html>
+<head><title>Authentication</title></head>
+<body>
+<script>
+const hash = window.location.hash.substring(1);
+const params = new URLSearchParams(hash);
+
+const formData = new URLSearchParams();
+formData.append('id_token', params.get('id_token') || '');
+formData.append('access_token', params.get('access_token') || '');
+formData.append('state', params.get('state') || '');
+formData.append('error', params.get('error') || '');
+formData.append('error_description', params.get('error_description') || '');
+
+fetch('/callback', {
+    method: 'POST',
+    headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: formData
+}).then(() => {
+    document.body.innerHTML = %s;
+}).catch(err => {
+    document.body.innerHTML = '<h1>Error</h1><p>' + err + '</p>';
+});
+</script>
+<p>Processing authentication...</p>
+</body>
+</html>`, quoteJavaScriptString(successHTML))
+	}
+
+	return `<!DOCTYPE html>
+<html>
+<head><title>Authentication Successful</title></head>
+<body>
+<script>
+const hash = window.location.hash.substring(1);
+const params = new URLSearchParams(hash);
+
+const formData = new URLSearchParams();
+formData.append('id_token', params.get('id_token') || '');
+formData.append('access_token', params.get('access_token') || '');
+formData.append('state', params.get('state') || '');
+formData.append('error', params.get('error') || '');
+formData.append('error_description', params.get('error_description') || '');
+
+fetch('/callback', {
+    method: 'POST',
+    headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: formData
+}).then(() => {
+    document.body.innerHTML = '<h1>Authentication Successful</h1><p>You can close this window.</p>';
+}).catch(err => {
+    document.body.innerHTML = '<h1>Error</h1><p>' + err + '</p>';
+});
+</script>
+<p>Processing authentication...</p>
+</body>
+</html>`
+}
+
+// processImplicitFlowTokens validates and processes the tokens from implicit flow
+func (c *client) processImplicitFlowTokens(ctx context.Context, tokens map[string]string, expectedState, expectedNonce string) (*oidc.TokenSet, error) {
+	if tokens["state"] != expectedState {
+		return nil, fmt.Errorf("state mismatch: expected %s, got %s", expectedState, tokens["state"])
+	}
+
+	idToken := tokens["id_token"]
+	if idToken == "" {
+		return nil, fmt.Errorf("no id_token in response")
+	}
+
+	// Implicit flow shouldn't have an access_token, check anyway
+	token := &oauth2.Token{
+		AccessToken: tokens["access_token"],
+		TokenType:   "Bearer",
+	}
+	token = token.WithExtra(map[string]interface{}{
+		"id_token": idToken,
+	})
+
+	return c.verifyToken(ctx, token, expectedNonce)
+}
+
+func quoteJavaScriptString(s string) string {
+	// Escape for JavaScript string literal
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "'", "\\'")
+	s = strings.ReplaceAll(s, "\n", "\\n")
+	s = strings.ReplaceAll(s, "\r", "\\r")
+	return "'" + s + "'"
+}

--- a/pkg/usecases/authentication/implicit/browser.go
+++ b/pkg/usecases/authentication/implicit/browser.go
@@ -1,0 +1,113 @@
+package implicit
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/int128/kubelogin/pkg/infrastructure/browser"
+	"github.com/int128/kubelogin/pkg/infrastructure/logger"
+	"github.com/int128/kubelogin/pkg/oidc"
+	"github.com/int128/kubelogin/pkg/oidc/client"
+	"golang.org/x/sync/errgroup"
+)
+
+type BrowserOption struct {
+	SkipOpenBrowser            bool
+	BrowserCommand             string
+	BindAddress                []string
+	AuthenticationTimeout      time.Duration
+	OpenURLAfterAuthentication string
+	AuthRequestExtraParams     map[string]string
+	LocalServerCertFile        string
+	LocalServerKeyFile         string
+}
+
+// Browser provides the implicit flow using the browser.
+type Browser struct {
+	Browser browser.Interface
+	Logger  logger.Interface
+}
+
+func (u *Browser) Do(ctx context.Context, o *BrowserOption, oidcClient client.Interface) (*oidc.TokenSet, error) {
+	u.Logger.V(1).Infof("starting the implicit flow using the browser")
+	state, err := oidc.NewState()
+	if err != nil {
+		return nil, fmt.Errorf("could not generate a state: %w", err)
+	}
+	nonce, err := oidc.NewNonce()
+	if err != nil {
+		return nil, fmt.Errorf("could not generate a nonce: %w", err)
+	}
+
+	successHTML := BrowserSuccessHTML
+	if o.OpenURLAfterAuthentication != "" {
+		successHTML = BrowserRedirectHTML(o.OpenURLAfterAuthentication)
+	}
+
+	in := client.GetTokenByImplicitFlowInput{
+		BindAddress:            o.BindAddress,
+		State:                  state,
+		Nonce:                  nonce,
+		AuthRequestExtraParams: o.AuthRequestExtraParams,
+		LocalServerSuccessHTML: successHTML,
+		LocalServerCertFile:    o.LocalServerCertFile,
+		LocalServerKeyFile:     o.LocalServerKeyFile,
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, o.AuthenticationTimeout)
+	defer cancel()
+	readyChan := make(chan string, 1)
+	var out *oidc.TokenSet
+	var eg errgroup.Group
+
+	eg.Go(func() error {
+		select {
+		case url, ok := <-readyChan:
+			if !ok {
+				return nil
+			}
+			u.openURL(ctx, o, url)
+			return nil
+		case <-ctx.Done():
+			return fmt.Errorf("context cancelled while waiting for the local server: %w", ctx.Err())
+		}
+	})
+	eg.Go(func() error {
+		defer close(readyChan)
+		tokenSet, err := oidcClient.GetTokenByImplicitFlow(ctx, in, readyChan)
+		if err != nil {
+			return fmt.Errorf("implicit flow error: %w", err)
+		}
+		out = tokenSet
+		u.Logger.V(1).Infof("got a token set by the implicit flow")
+		return nil
+	})
+	if err := eg.Wait(); err != nil {
+		return nil, fmt.Errorf("authentication error: %w", err)
+	}
+	u.Logger.V(1).Infof("finished the implicit flow via the browser")
+	return out, nil
+}
+
+func (u *Browser) openURL(ctx context.Context, o *BrowserOption, url string) {
+	if o.SkipOpenBrowser {
+		u.Logger.Printf("Please visit the following URL in your browser: %s", url)
+		return
+	}
+
+	u.Logger.V(1).Infof("opening %s in the browser", url)
+	if o.BrowserCommand != "" {
+		if err := u.Browser.OpenCommand(ctx, url, o.BrowserCommand); err != nil {
+			u.Logger.Printf(`error: could not open the browser: %s
+
+Please visit the following URL in your browser manually: %s`, err, url)
+		}
+		return
+	}
+	if err := u.Browser.Open(url); err != nil {
+		u.Logger.Printf(`error: could not open the browser: %s
+
+Please visit the following URL in your browser manually: %s`, err, url)
+	}
+}

--- a/pkg/usecases/authentication/implicit/browser_html.go
+++ b/pkg/usecases/authentication/implicit/browser_html.go
@@ -1,0 +1,31 @@
+package implicit
+
+import "fmt"
+
+// BrowserSuccessHTML is the HTML page shown after successful authentication
+const BrowserSuccessHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Authentication Successful</title>
+</head>
+<body>
+    <h1>Authentication Successful</h1>
+    <p>You can close this window.</p>
+</body>
+</html>`
+
+// BrowserRedirectHTML returns HTML that redirects to the given URL
+func BrowserRedirectHTML(url string) string {
+	return fmt.Sprintf(`<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0;url=%s">
+    <title>Authentication Successful</title>
+</head>
+<body>
+    <p>Redirecting to <a href="%s">%s</a>...</p>
+</body>
+</html>`, url, url, url)
+}

--- a/pkg/usecases/authentication/implicit/browser_test.go
+++ b/pkg/usecases/authentication/implicit/browser_test.go
@@ -1,0 +1,143 @@
+package implicit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/int128/kubelogin/mocks/github.com/int128/kubelogin/pkg/infrastructure/browser_mock"
+	"github.com/int128/kubelogin/mocks/github.com/int128/kubelogin/pkg/oidc/client_mock"
+	"github.com/int128/kubelogin/pkg/oidc"
+	"github.com/int128/kubelogin/pkg/oidc/client"
+	"github.com/int128/kubelogin/pkg/testing/logger"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestBrowser_Do(t *testing.T) {
+	timeout := 5 * time.Second
+
+	t.Run("Success", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		o := &BrowserOption{
+			BindAddress:                []string{"127.0.0.1:8000"},
+			SkipOpenBrowser:            true,
+			AuthenticationTimeout:      10 * time.Second,
+			LocalServerCertFile:        "/path/to/local-server-cert",
+			LocalServerKeyFile:         "/path/to/local-server-key",
+			OpenURLAfterAuthentication: "https://example.com/success.html",
+			AuthRequestExtraParams:     map[string]string{"ttl": "86400", "reauth": "true"},
+		}
+		mockClient := client_mock.NewMockInterface(t)
+		mockClient.EXPECT().
+			GetTokenByImplicitFlow(mock.Anything, mock.Anything, mock.Anything).
+			Run(func(_ context.Context, in client.GetTokenByImplicitFlowInput, readyChan chan<- string) {
+				if diff := cmp.Diff(o.BindAddress, in.BindAddress); diff != "" {
+					t.Errorf("BindAddress mismatch (-want +got):\n%s", diff)
+				}
+				if diff := cmp.Diff(BrowserRedirectHTML("https://example.com/success.html"), in.LocalServerSuccessHTML); diff != "" {
+					t.Errorf("LocalServerSuccessHTML mismatch (-want +got):\n%s", diff)
+				}
+				if diff := cmp.Diff(o.AuthRequestExtraParams, in.AuthRequestExtraParams); diff != "" {
+					t.Errorf("AuthRequestExtraParams mismatch (-want +got):\n%s", diff)
+				}
+				if diff := cmp.Diff(o.LocalServerKeyFile, in.LocalServerKeyFile); diff != "" {
+					t.Errorf("LocalServerKeyFile mismatch (-want +got):\n%s", diff)
+				}
+				if diff := cmp.Diff(o.LocalServerCertFile, in.LocalServerCertFile); diff != "" {
+					t.Errorf("LocalServerCertFile mismatch (-want +got):\n%s", diff)
+				}
+				readyChan <- "LOCAL_SERVER_URL"
+			}).
+			Return(&oidc.TokenSet{
+				IDToken: "YOUR_ID_TOKEN",
+			}, nil)
+		u := Browser{
+			Logger: logger.New(t),
+		}
+		got, err := u.Do(ctx, o, mockClient)
+		if err != nil {
+			t.Errorf("Do returned error: %+v", err)
+		}
+		want := &oidc.TokenSet{
+			IDToken: "YOUR_ID_TOKEN",
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("OpenBrowser", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+		defer cancel()
+		o := &BrowserOption{
+			BindAddress:           []string{"127.0.0.1:8000"},
+			AuthenticationTimeout: 10 * time.Second,
+		}
+		mockClient := client_mock.NewMockInterface(t)
+		mockClient.EXPECT().
+			GetTokenByImplicitFlow(mock.Anything, mock.Anything, mock.Anything).
+			Run(func(_ context.Context, _ client.GetTokenByImplicitFlowInput, readyChan chan<- string) {
+				readyChan <- "LOCAL_SERVER_URL"
+			}).
+			Return(&oidc.TokenSet{
+				IDToken: "YOUR_ID_TOKEN",
+			}, nil)
+		mockBrowser := browser_mock.NewMockInterface(t)
+		mockBrowser.EXPECT().
+			Open("LOCAL_SERVER_URL").
+			Return(nil)
+		u := Browser{
+			Logger:  logger.New(t),
+			Browser: mockBrowser,
+		}
+		got, err := u.Do(ctx, o, mockClient)
+		if err != nil {
+			t.Errorf("Do returned error: %+v", err)
+		}
+		want := &oidc.TokenSet{
+			IDToken: "YOUR_ID_TOKEN",
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("OpenBrowserCommand", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+		defer cancel()
+		o := &BrowserOption{
+			BindAddress:           []string{"127.0.0.1:8000"},
+			BrowserCommand:        "firefox",
+			AuthenticationTimeout: 10 * time.Second,
+		}
+		mockClient := client_mock.NewMockInterface(t)
+		mockClient.EXPECT().
+			GetTokenByImplicitFlow(mock.Anything, mock.Anything, mock.Anything).
+			Run(func(_ context.Context, _ client.GetTokenByImplicitFlowInput, readyChan chan<- string) {
+				readyChan <- "LOCAL_SERVER_URL"
+			}).
+			Return(&oidc.TokenSet{
+				IDToken: "YOUR_ID_TOKEN",
+			}, nil)
+		mockBrowser := browser_mock.NewMockInterface(t)
+		mockBrowser.EXPECT().
+			OpenCommand(mock.Anything, "LOCAL_SERVER_URL", "firefox").
+			Return(nil)
+		u := Browser{
+			Logger:  logger.New(t),
+			Browser: mockBrowser,
+		}
+		got, err := u.Do(ctx, o, mockClient)
+		if err != nil {
+			t.Errorf("Do returned error: %+v", err)
+		}
+		want := &oidc.TokenSet{
+			IDToken: "YOUR_ID_TOKEN",
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+}


### PR DESCRIPTION
The main reason I am looking to add this is to allow user claims (specifically groups) to be included in the signed id token that can be consumed by the Kubernetes API to bind roles based on an OpenID user's groups.

