### PR TITLE
fix: support opaque access tokens

### DIFF
--- a/pkg/oidc/client/client.go
+++ b/pkg/oidc/client/client.go
@@ -81,22 +81,12 @@ func (c *client) verifyToken(ctx context.Context, token *oauth2.Token, nonce str
 			return nil, fmt.Errorf("access_token is missing in the token response: %#v", accessToken)
 		}
 
-		// We intentionally do not perform a ClientID check here because there
-		// are some use cases in access_tokens where we *expect* the audience
-		// to differ. For example, one can explicitly set
-		// `audience=CLUSTER_CLIENT_ID` as an extra auth parameter.
-		verifier = c.provider.Verifier(&gooidc.Config{ClientID: "", Now: c.clock.Now, SkipClientIDCheck: true})
-
-		_, err := verifier.Verify(ctx, accessToken)
-		if err != nil {
-			return nil, fmt.Errorf("could not verify the access token: %w", err)
-		}
-
 		// There is no `nonce` to check on the `access_token`. We rely on the
 		// above `nonce` check on the `id_token`.
-
+		// Opaque access tokens are valid under OIDC, thus we cannot verify it without making calls to provider-specific endpoints.
 		return &oidc.TokenSet{
-			IDToken:      accessToken,
+			IDToken:      idToken,
+			AccessToken:  token.AccessToken,
 			RefreshToken: token.RefreshToken,
 		}, nil
 	}

--- a/pkg/oidc/oidc.go
+++ b/pkg/oidc/oidc.go
@@ -33,11 +33,19 @@ const (
 // TokenSet represents a set of ID token and refresh token.
 type TokenSet struct {
 	IDToken      string
+	AccessToken  string
 	RefreshToken string
 }
 
 func (ts TokenSet) DecodeWithoutVerify() (*jwt.Claims, error) {
 	return jwt.DecodeWithoutVerify(ts.IDToken)
+}
+
+func (p *Provider) SelectToken(ts *TokenSet) string {
+	if p.UseAccessToken {
+		return ts.AccessToken
+	}
+	return ts.IDToken
 }
 
 func NewState() (string, error) {

--- a/pkg/tokencache/repository/repository.go
+++ b/pkg/tokencache/repository/repository.go
@@ -32,6 +32,7 @@ type Interface interface {
 
 type entity struct {
 	IDToken      string `json:"id_token,omitempty"`
+	AccessToken  string `json:"access_token,omitempty"`
 	RefreshToken string `json:"refresh_token,omitempty"`
 }
 
@@ -98,6 +99,7 @@ func decodeKey(b []byte) (*oidc.TokenSet, error) {
 	}
 	return &oidc.TokenSet{
 		IDToken:      e.IDToken,
+		AccessToken:  e.AccessToken,
 		RefreshToken: e.RefreshToken,
 	}, nil
 }
@@ -196,6 +198,7 @@ func (r *Repository) DeleteAll(config tokencache.Config) error {
 func encodeKey(tokenSet oidc.TokenSet) ([]byte, error) {
 	e := entity{
 		IDToken:      tokenSet.IDToken,
+		AccessToken:  tokenSet.AccessToken,
 		RefreshToken: tokenSet.RefreshToken,
 	}
 	return json.Marshal(&e)

--- a/pkg/usecases/credentialplugin/get_token.go
+++ b/pkg/usecases/credentialplugin/get_token.go
@@ -96,7 +96,7 @@ func (u *GetToken) Do(ctx context.Context, in Input) error {
 			if !claims.IsExpired(u.Clock) {
 				u.Logger.V(1).Infof("you already have a valid token until %s", claims.Expiry)
 				out := credentialplugin.Output{
-					Token:                          cachedTokenSet.IDToken,
+					Token:                          in.Provider.SelectToken(cachedTokenSet),
 					Expiry:                         claims.Expiry,
 					ClientAuthenticationAPIVersion: credentialPluginInput.ClientAuthenticationAPIVersion,
 				}
@@ -130,7 +130,7 @@ func (u *GetToken) Do(ctx context.Context, in Input) error {
 	}
 	u.Logger.V(1).Infof("writing the token to client-go")
 	out := credentialplugin.Output{
-		Token:                          authenticationOutput.TokenSet.IDToken,
+		Token:                          in.Provider.SelectToken(&authenticationOutput.TokenSet),
 		Expiry:                         idTokenClaims.Expiry,
 		ClientAuthenticationAPIVersion: credentialPluginInput.ClientAuthenticationAPIVersion,
 	}


### PR DESCRIPTION
### Follow up to: https://github.com/int128/kubelogin/pull/1084

This PR separates access tokens from id tokens, and removes overly-restrictive validation of them. As mentioned in https://github.com/int128/kubelogin/pull/1084#discussion_r1623184775, the OAuth2 + OIDC specs do not require access tokens to be JWTs. This means that opaque tokens, which have no defined shape, are perfectly valid. Thus, it is a deviation from the spec to require them to be a JWT. 

Further, this deviation from the spec blocks real-world use cases without much gain. While it is nice to check token validity on the client, this client-side check is inherently stale (_e.g. revocations, TOCTOU diff, etc..._). So graceful handling of said invalid token is probably desirable regardless?

#### Specific example / use-case:
Google uses exactly this opaque access token format. These access tokens can be used to authenticate agains GKE clusters. The current behavior blocks this use case unnecessarily. 

I am aware of Google's `gcloud` kubectl plugin. There are several reasons kubelogin is much preferable, including:
- gcloud plugin dumps tokens in plain text to disk (_this is a non-starter tbh_)
- kubelogin is useful across many other clusters b/c it is standard OIDC 
- kubelogin is much more simple to deal with vs the whole `gcloud` cli + mass of python deps/components