### PR TITLE
feat: add --oidc-device-authorization-url flag to support GitLab 17.x device authorization grant

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,6 +14,7 @@ Flags:
       --oidc-extra-scope strings                        Scopes to request to the provider
       --oidc-use-access-token                           Instead of using the id_token, use the access_token to authenticate to Kubernetes
       --oidc-request-header stringToString              HTTP headers to send with an authentication request (default [])
+      --oidc-device-authorization-url string            [device-code] Override the device_authorization_endpoint URL (e.g: <issuer>/oauth/authorize_device)
       --force-refresh                                   If set, refresh the ID token regardless of its expiration time
       --token-cache-dir string                          Path to a directory of the token cache (default "~/.kube/cache/oidc-login")
       --token-cache-storage string                      Storage for the token cache. One of (disk|keyring|none) (default "disk")
@@ -164,6 +165,12 @@ It performs the [Device Authorization Grant (RFC 8628)](https://tools.ietf.org/h
 It automatically opens the browser.
 If the provider returns the `verification_uri_complete` parameter, you don't need to enter the code.
 Otherwise, you need to enter the code shown.
+
+If your provider does not advertise `device_authorization_endpoint` in its OIDC discovery document (e.g. GitLab 17.x), you can override the URL manually:
+
+```yaml
+- --oidc-device-authorization-url=https://gitlab.example.com/oauth/authorize_device
+```
 
 If you encounter a problem with the browser, you can change the browser command or skip opening the browser.
 

--- a/pkg/cmd/get_token.go
+++ b/pkg/cmd/get_token.go
@@ -13,18 +13,19 @@ import (
 
 // getTokenOptions represents the options for get-token command.
 type getTokenOptions struct {
-	IssuerURL             string
-	ClientID              string
-	ClientSecret          string
-	RedirectURL           string
-	ExtraScopes           []string
-	UseAccessToken        bool
-	RequestHeaders        map[string]string
-	tokenCacheOptions     tokenCacheOptions
-	tlsOptions            tlsOptions
-	pkceOptions           pkceOptions
-	authenticationOptions authenticationOptions
-	ForceRefresh          bool
+	IssuerURL              string
+	ClientID               string
+	ClientSecret           string
+	RedirectURL            string
+	ExtraScopes            []string
+	UseAccessToken         bool
+	RequestHeaders         map[string]string
+	DeviceAuthorizationURL string
+	tokenCacheOptions      tokenCacheOptions
+	tlsOptions             tlsOptions
+	pkceOptions            pkceOptions
+	authenticationOptions  authenticationOptions
+	ForceRefresh           bool
 }
 
 func (o *getTokenOptions) addFlags(f *pflag.FlagSet) {
@@ -35,6 +36,7 @@ func (o *getTokenOptions) addFlags(f *pflag.FlagSet) {
 	f.StringSliceVar(&o.ExtraScopes, "oidc-extra-scope", nil, "Scopes to request to the provider")
 	f.BoolVar(&o.UseAccessToken, "oidc-use-access-token", false, "Instead of using the id_token, use the access_token to authenticate to Kubernetes")
 	f.StringToStringVar(&o.RequestHeaders, "oidc-request-header", nil, "HTTP headers to send with an authentication request")
+	f.StringVar(&o.DeviceAuthorizationURL, "oidc-device-authorization-url", "", "[device-code] Override the device_authorization_endpoint URL (e.g. GitLab: <issuer>/oauth/authorize_device)")
 	f.BoolVar(&o.ForceRefresh, "force-refresh", false, "If set, refresh the ID token regardless of its expiration time")
 	o.tokenCacheOptions.addFlags(f)
 	o.tlsOptions.addFlags(f)
@@ -86,14 +88,15 @@ func (cmd *GetToken) New() *cobra.Command {
 			}
 			in := credentialplugin.Input{
 				Provider: oidc.Provider{
-					IssuerURL:      o.IssuerURL,
-					ClientID:       o.ClientID,
-					ClientSecret:   o.ClientSecret,
-					RedirectURL:    o.RedirectURL,
-					PKCEMethod:     pkceMethod,
-					UseAccessToken: o.UseAccessToken,
-					ExtraScopes:    o.ExtraScopes,
-					RequestHeaders: o.RequestHeaders,
+					IssuerURL:              o.IssuerURL,
+					ClientID:               o.ClientID,
+					ClientSecret:           o.ClientSecret,
+					RedirectURL:            o.RedirectURL,
+					PKCEMethod:             pkceMethod,
+					UseAccessToken:         o.UseAccessToken,
+					ExtraScopes:            o.ExtraScopes,
+					RequestHeaders:         o.RequestHeaders,
+					DeviceAuthorizationURL: o.DeviceAuthorizationURL,
 				},
 				ForceRefresh:     o.ForceRefresh,
 				TokenCacheConfig: tokenCacheConfig,

--- a/pkg/cmd/setup.go
+++ b/pkg/cmd/setup.go
@@ -12,16 +12,17 @@ import (
 
 // setupOptions represents the options for setup command.
 type setupOptions struct {
-	IssuerURL             string
-	ClientID              string
-	ClientSecret          string
-	RedirectURL           string
-	ExtraScopes           []string
-	UseAccessToken        bool
-	RequestHeaders        map[string]string
-	tlsOptions            tlsOptions
-	pkceOptions           pkceOptions
-	authenticationOptions authenticationOptions
+	IssuerURL              string
+	ClientID               string
+	ClientSecret           string
+	RedirectURL            string
+	ExtraScopes            []string
+	UseAccessToken         bool
+	RequestHeaders         map[string]string
+	DeviceAuthorizationURL string
+	tlsOptions             tlsOptions
+	pkceOptions            pkceOptions
+	authenticationOptions  authenticationOptions
 }
 
 func (o *setupOptions) addFlags(f *pflag.FlagSet) {
@@ -32,6 +33,7 @@ func (o *setupOptions) addFlags(f *pflag.FlagSet) {
 	f.StringSliceVar(&o.ExtraScopes, "oidc-extra-scope", nil, "Scopes to request to the provider")
 	f.BoolVar(&o.UseAccessToken, "oidc-use-access-token", false, "Instead of using the id_token, use the access_token to authenticate to Kubernetes")
 	f.StringToStringVar(&o.RequestHeaders, "oidc-request-header", nil, "HTTP headers to send with an authentication request")
+	f.StringVar(&o.DeviceAuthorizationURL, "oidc-device-authorization-url", "", "[device-code] Override the device_authorization_endpoint URL (e.g. GitLab: <issuer>/oauth/authorize_device)")
 	o.tlsOptions.addFlags(f)
 	o.pkceOptions.addFlags(f)
 	o.authenticationOptions.addFlags(f)
@@ -75,17 +77,18 @@ func (cmd *Setup) New() *cobra.Command {
 				return fmt.Errorf("setup: %w", err)
 			}
 			in := setup.Input{
-				IssuerURL:       o.IssuerURL,
-				ClientID:        o.ClientID,
-				ClientSecret:    o.ClientSecret,
-				RedirectURL:     o.RedirectURL,
-				ExtraScopes:     o.ExtraScopes,
-				UseAccessToken:  o.UseAccessToken,
-				RequestHeaders:  o.RequestHeaders,
-				PKCEMethod:      pkceMethod,
-				GrantOptionSet:  grantOptionSet,
-				TLSClientConfig: o.tlsOptions.tlsClientConfig(),
-				ChangedFlags:    changedFlags,
+				IssuerURL:              o.IssuerURL,
+				ClientID:               o.ClientID,
+				ClientSecret:           o.ClientSecret,
+				RedirectURL:            o.RedirectURL,
+				ExtraScopes:            o.ExtraScopes,
+				UseAccessToken:         o.UseAccessToken,
+				RequestHeaders:         o.RequestHeaders,
+				DeviceAuthorizationURL: o.DeviceAuthorizationURL,
+				PKCEMethod:             pkceMethod,
+				GrantOptionSet:         grantOptionSet,
+				TLSClientConfig:        o.tlsOptions.tlsClientConfig(),
+				ChangedFlags:           changedFlags,
 			}
 			if in.IssuerURL == "" || in.ClientID == "" {
 				return c.Help()

--- a/pkg/oidc/client/devicecode.go
+++ b/pkg/oidc/client/devicecode.go
@@ -13,8 +13,12 @@ import (
 func (c *client) GetDeviceAuthorization(ctx context.Context) (*oauth2dev.AuthorizationResponse, error) {
 	ctx = c.wrapContext(ctx)
 	config := c.oauth2Config
+	deviceAuthURL := c.provider.Endpoint().DeviceAuthURL
+	if deviceAuthURL == "" {
+		deviceAuthURL = c.oauth2Config.Endpoint.DeviceAuthURL
+	}
 	config.Endpoint = oauth2.Endpoint{
-		AuthURL: c.provider.Endpoint().DeviceAuthURL,
+		AuthURL: deviceAuthURL,
 	}
 	return oauth2dev.RetrieveCode(ctx, config)
 }

--- a/pkg/oidc/client/factory.go
+++ b/pkg/oidc/client/factory.go
@@ -67,6 +67,9 @@ func (f *Factory) New(ctx context.Context, prov oidc.Provider, tlsClientConfig t
 	if prov.ClientSecret == "" {
 		endpoint.AuthStyle = oauth2.AuthStyleInParams
 	}
+	if endpoint.DeviceAuthURL == "" && prov.DeviceAuthorizationURL != "" {
+		endpoint.DeviceAuthURL = prov.DeviceAuthorizationURL
+	}
 
 	return &client{
 		httpClient: httpClient,

--- a/pkg/oidc/oidc.go
+++ b/pkg/oidc/oidc.go
@@ -11,14 +11,15 @@ import (
 
 // Provider represents an OIDC provider.
 type Provider struct {
-	IssuerURL      string
-	ClientID       string
-	ClientSecret   string   // optional
-	ExtraScopes    []string // optional
-	RedirectURL    string   // optional
-	PKCEMethod     PKCEMethod
-	UseAccessToken bool
-	RequestHeaders map[string]string
+	IssuerURL              string
+	ClientID               string
+	ClientSecret           string   // optional
+	ExtraScopes            []string // optional
+	RedirectURL            string   // optional
+	PKCEMethod             PKCEMethod
+	UseAccessToken         bool
+	RequestHeaders         map[string]string
+	DeviceAuthorizationURL string // optional: overrides device_authorization_endpoint from discovery (e.g. GitLab omits it)
 }
 
 // PKCEMethod represents a preferred method of PKCE.

--- a/pkg/usecases/setup/setup.go
+++ b/pkg/usecases/setup/setup.go
@@ -39,31 +39,33 @@ var setupTemplate = template.Must(template.New("setup.md").Funcs(template.FuncMa
 }).Parse(setupMarkdown))
 
 type Input struct {
-	IssuerURL       string
-	ClientID        string
-	ClientSecret    string
-	RedirectURL     string
-	ExtraScopes     []string
-	UseAccessToken  bool
-	RequestHeaders  map[string]string
-	PKCEMethod      oidc.PKCEMethod
-	GrantOptionSet  authentication.GrantOptionSet
-	TLSClientConfig tlsclientconfig.Config
-	ChangedFlags    []string
+	IssuerURL              string
+	ClientID               string
+	ClientSecret           string
+	RedirectURL            string
+	ExtraScopes            []string
+	UseAccessToken         bool
+	RequestHeaders         map[string]string
+	DeviceAuthorizationURL string
+	PKCEMethod             oidc.PKCEMethod
+	GrantOptionSet         authentication.GrantOptionSet
+	TLSClientConfig        tlsclientconfig.Config
+	ChangedFlags           []string
 }
 
 func (u Setup) Do(ctx context.Context, in Input) error {
 	u.Logger.Printf("Authentication in progress...")
 	out, err := u.Authentication.Do(ctx, authentication.Input{
 		Provider: oidc.Provider{
-			IssuerURL:      in.IssuerURL,
-			ClientID:       in.ClientID,
-			ClientSecret:   in.ClientSecret,
-			RedirectURL:    in.RedirectURL,
-			ExtraScopes:    in.ExtraScopes,
-			PKCEMethod:     in.PKCEMethod,
-			UseAccessToken: in.UseAccessToken,
-			RequestHeaders: in.RequestHeaders,
+			IssuerURL:              in.IssuerURL,
+			ClientID:               in.ClientID,
+			ClientSecret:           in.ClientSecret,
+			RedirectURL:            in.RedirectURL,
+			ExtraScopes:            in.ExtraScopes,
+			PKCEMethod:             in.PKCEMethod,
+			UseAccessToken:         in.UseAccessToken,
+			RequestHeaders:         in.RequestHeaders,
+			DeviceAuthorizationURL: in.DeviceAuthorizationURL,
 		},
 		GrantOptionSet:  in.GrantOptionSet,
 		TLSClientConfig: in.TLSClientConfig,


### PR DESCRIPTION
Closes #1584

## Problem

GitLab 17.x supports the Device Authorization Grant (`device_code`) but omits
`device_authorization_endpoint` from its OIDC discovery document. When kubelogin
attempts device-code authentication against such a provider, it reads an empty string
from discovery and fails immediately:

```txt
authorization error: unable to send the request: Post "": unsupported protocol scheme ""
```

There is no flag to supply the endpoint manually, so the only workaround today is
patching the binary.

## Solution

Add `--oidc-device-authorization-url` to both `get-token` and `setup`. When the flag
is set and the discovery document returns an empty `device_authorization_endpoint`,
the provided value is used instead. If the provider does advertise the endpoint,
the flag has no effect.

For GitLab 17.x:

```txt
--oidc-device-authorization-url=https://<gitlab-host>/oauth/authorize_device
```

## Changes

| File | Change |
|---|---|
| `pkg/oidc/oidc.go` | Added `DeviceAuthorizationURL` field to `Provider` struct |
| `pkg/oidc/client/factory.go` | Apply override when `endpoint.DeviceAuthURL` is empty after discovery |
| `pkg/oidc/client/devicecode.go` | Prefer discovery URL, fall back to `oauth2Config` endpoint |
| `pkg/cmd/get_token.go` | Register flag, wire value through to `oidc.Provider` |
| `pkg/cmd/setup.go` | Register flag, wire value through to `setup.Input` |
| `pkg/usecases/setup/setup.go` | Propagate `DeviceAuthorizationURL` to `oidc.Provider` |
| `docs/usage.md` | Document the flag and the GitLab 17.x workaround |

## Behaviour

- Providers that advertise `device_authorization_endpoint` in discovery are unaffected.
- The override is applied in `factory.go` after the discovery document is parsed, so
  it is a single, auditable injection point.
- No changes to the device-code exchange logic (`ExchangeDeviceCode`).

## Testing

Verified against a GitLab 17.5 instance, which omits `device_authorization_endpoint`
from `/.well-known/openid-configuration`. With the flag set to
`https://<host>/oauth/authorize_device`, device-code authentication completes
successfully.

Existing unit tests pass unchanged.
