### PR TITLE
Add support for PKCE in device code grant

### DIFF
--- a/integration_test/credetial_plugin_test.go
+++ b/integration_test/credetial_plugin_test.go
@@ -198,6 +198,57 @@ func TestCredentialPlugin(t *testing.T) {
 		})
 	}
 
+	t.Run("DeviceCode", func(t *testing.T) {
+		t.Run("WithoutPKCE", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+			defer cancel()
+			svc := oidcserver.New(t, keypair.None, testconfig.Config{
+				Want: testconfig.Want{
+					Scope:               "openid",
+					CodeChallengeMethod: "",
+				},
+				Response: testconfig.Response{
+					IDTokenExpiry: now.Add(time.Hour),
+				},
+			})
+			var stdout bytes.Buffer
+			runGetToken(t, ctx, getTokenConfig{
+				tokenCacheDir: tokenCacheDir,
+				issuerURL:     svc.IssuerURL(),
+				httpDriver:    httpdriver.Zero(t),
+				now:           now,
+				stdout:        &stdout,
+				args:          []string{"--grant-type", "device-code", "--skip-open-browser"},
+			})
+			assertCredentialPluginStdout(t, &stdout, svc.LastTokenResponse().IDToken, now.Add(time.Hour))
+		})
+
+		t.Run("WithPKCE", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+			defer cancel()
+			svc := oidcserver.New(t, keypair.None, testconfig.Config{
+				Want: testconfig.Want{
+					Scope:               "openid",
+					CodeChallengeMethod: "S256",
+				},
+				Response: testconfig.Response{
+					IDTokenExpiry:                 now.Add(time.Hour),
+					CodeChallengeMethodsSupported: []string{"S256"},
+				},
+			})
+			var stdout bytes.Buffer
+			runGetToken(t, ctx, getTokenConfig{
+				tokenCacheDir: tokenCacheDir,
+				issuerURL:     svc.IssuerURL(),
+				httpDriver:    httpdriver.Zero(t),
+				now:           now,
+				stdout:        &stdout,
+				args:          []string{"--grant-type", "device-code", "--skip-open-browser"},
+			})
+			assertCredentialPluginStdout(t, &stdout, svc.LastTokenResponse().IDToken, now.Add(time.Hour))
+		})
+	})
+
 	t.Run("PKCE", func(t *testing.T) {
 		t.Run("Not supported by provider", func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.TODO(), timeout)

--- a/integration_test/oidcserver/handler/handler.go
+++ b/integration_test/oidcserver/handler/handler.go
@@ -18,6 +18,7 @@ func Register(t *testing.T, mux *http.ServeMux, provider service.Provider) {
 	mux.HandleFunc("GET /certs", h.GetCertificates)
 	mux.HandleFunc("GET /auth", h.AuthenticateCode)
 	mux.HandleFunc("POST /token", h.Exchange)
+	mux.HandleFunc("POST /device", h.DeviceAuthorization)
 }
 
 // Handlers provides HTTP handlers for the OpenID Connect Provider.
@@ -143,6 +144,18 @@ func (h *Handlers) Exchange(w http.ResponseWriter, r *http.Request) {
 			if err := e.Encode(tokenResponse); err != nil {
 				return fmt.Errorf("could not render json: %w", err)
 			}
+		case "urn:ietf:params:oauth:grant-type:device_code":
+			tokenResponse, err := h.provider.ExchangeDeviceCode(service.DeviceCodeTokenRequest{
+				DeviceCode:   r.Form.Get("device_code"),
+				CodeVerifier: r.Form.Get("code_verifier"),
+			})
+			if err != nil {
+				return fmt.Errorf("device code exchange error: %w", err)
+			}
+			w.Header().Add("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(tokenResponse); err != nil {
+				return fmt.Errorf("could not render json: %w", err)
+			}
 		default:
 			// 5.2. Error Response
 			// https://tools.ietf.org/html/rfc6749#section-5.2
@@ -150,6 +163,27 @@ func (h *Handlers) Exchange(w http.ResponseWriter, r *http.Request) {
 				Code:        "invalid_grant",
 				Description: fmt.Sprintf("unknown grant_type %s", grantType),
 			}
+		}
+		return nil
+	})
+}
+
+func (h *Handlers) DeviceAuthorization(w http.ResponseWriter, r *http.Request) {
+	h.handleError(w, r, func() error {
+		if err := r.ParseForm(); err != nil {
+			return fmt.Errorf("could not parse the form: %w", err)
+		}
+		resp, err := h.provider.DeviceAuthorization(service.DeviceAuthorizationRequest{
+			Scope:               r.Form.Get("scope"),
+			CodeChallenge:       r.Form.Get("code_challenge"),
+			CodeChallengeMethod: r.Form.Get("code_challenge_method"),
+		})
+		if err != nil {
+			return fmt.Errorf("device authorization error: %w", err)
+		}
+		w.Header().Add("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			return fmt.Errorf("could not render json: %w", err)
 		}
 		return nil
 	})

--- a/integration_test/oidcserver/service/service.go
+++ b/integration_test/oidcserver/service/service.go
@@ -24,11 +24,12 @@ func New(t *testing.T, issuerURL string, config testconfig.Config) Service {
 }
 
 type service struct {
-	config                    testconfig.Config
-	t                         *testing.T
-	issuerURL                 string
-	lastAuthenticationRequest *AuthenticationRequest
-	lastTokenResponse         *TokenResponse
+	config                      testconfig.Config
+	t                           *testing.T
+	issuerURL                   string
+	lastAuthenticationRequest   *AuthenticationRequest
+	lastTokenResponse           *TokenResponse
+	lastDeviceAuthorizationRequest *DeviceAuthorizationRequest
 }
 
 func (svc *service) IssuerURL() string {
@@ -49,6 +50,7 @@ func (svc *service) Discovery() *DiscoveryResponse {
 		Issuer:                            svc.issuerURL,
 		AuthorizationEndpoint:             svc.issuerURL + "/auth",
 		TokenEndpoint:                     svc.issuerURL + "/token",
+		DeviceAuthorizationEndpoint:       svc.issuerURL + "/device",
 		JwksURI:                           svc.issuerURL + "/certs",
 		UserinfoEndpoint:                  svc.issuerURL + "/userinfo",
 		RevocationEndpoint:                svc.issuerURL + "/revoke",
@@ -121,6 +123,51 @@ func (svc *service) Exchange(req TokenRequest) (*TokenResponse, error) {
 			claims.ExpiresAt = jwt.NewNumericDate(svc.config.Response.IDTokenExpiry)
 			claims.Audience = []string{"kubernetes"}
 			claims.Nonce = svc.lastAuthenticationRequest.Nonce
+		}),
+	}
+	svc.lastTokenResponse = resp
+	return resp, nil
+}
+
+func (svc *service) DeviceAuthorization(req DeviceAuthorizationRequest) (*DeviceAuthorizationResponse, error) {
+	if req.Scope != svc.config.Want.Scope {
+		svc.t.Errorf("scope wants `%s` but was `%s`", svc.config.Want.Scope, req.Scope)
+	}
+	if diff := cmp.Diff(svc.config.Want.CodeChallengeMethod, req.CodeChallengeMethod); diff != "" {
+		svc.t.Errorf("code_challenge_method mismatch (-want +got):\n%s", diff)
+	}
+	svc.lastDeviceAuthorizationRequest = &req
+	return &DeviceAuthorizationResponse{
+		DeviceCode:      "TEST-DEVICE-CODE",
+		UserCode:        "TEST-USER-CODE",
+		VerificationURI: svc.issuerURL + "/activate",
+		ExpiresIn:       300,
+		Interval:        1,
+	}, nil
+}
+
+func (svc *service) ExchangeDeviceCode(req DeviceCodeTokenRequest) (*TokenResponse, error) {
+	if req.DeviceCode != "TEST-DEVICE-CODE" {
+		return nil, &ErrorResponse{Code: "invalid_grant", Description: fmt.Sprintf("unknown device_code %s", req.DeviceCode)}
+	}
+	if svc.lastDeviceAuthorizationRequest != nil && svc.lastDeviceAuthorizationRequest.CodeChallengeMethod == "S256" {
+		challenge := computeS256Challenge(req.CodeVerifier)
+		if challenge != svc.lastDeviceAuthorizationRequest.CodeChallenge {
+			svc.t.Errorf("pkce S256 challenge did not match (want %s but got %s)",
+				svc.lastDeviceAuthorizationRequest.CodeChallenge, challenge)
+		}
+	}
+	resp := &TokenResponse{
+		TokenType:    "Bearer",
+		ExpiresIn:    3600,
+		AccessToken:  "YOUR_ACCESS_TOKEN",
+		RefreshToken: svc.config.Response.RefreshToken,
+		IDToken: testingJWT.EncodeF(svc.t, func(claims *testingJWT.Claims) {
+			claims.Issuer = svc.issuerURL
+			claims.Subject = "SUBJECT"
+			claims.IssuedAt = jwt.NewNumericDate(svc.config.Response.IDTokenExpiry.Add(-time.Hour))
+			claims.ExpiresAt = jwt.NewNumericDate(svc.config.Response.IDTokenExpiry)
+			claims.Audience = []string{"kubernetes"}
 		}),
 	}
 	svc.lastTokenResponse = resp

--- a/integration_test/oidcserver/service/types.go
+++ b/integration_test/oidcserver/service/types.go
@@ -29,6 +29,31 @@ type Provider interface {
 	Exchange(req TokenRequest) (*TokenResponse, error)
 	AuthenticatePassword(username, password, scope string) (*TokenResponse, error)
 	Refresh(refreshToken string) (*TokenResponse, error)
+	DeviceAuthorization(req DeviceAuthorizationRequest) (*DeviceAuthorizationResponse, error)
+	ExchangeDeviceCode(req DeviceCodeTokenRequest) (*TokenResponse, error)
+}
+
+// DeviceAuthorizationRequest represents RFC 8628 device authorization request parameters.
+type DeviceAuthorizationRequest struct {
+	Scope               string
+	CodeChallenge       string
+	CodeChallengeMethod string
+}
+
+// DeviceAuthorizationResponse represents RFC 8628 device authorization response.
+type DeviceAuthorizationResponse struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete,omitempty"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+}
+
+// DeviceCodeTokenRequest represents a token request for the device code grant type.
+type DeviceCodeTokenRequest struct {
+	DeviceCode   string
+	CodeVerifier string
 }
 
 // DiscoveryResponse represents the type of:
@@ -37,6 +62,7 @@ type DiscoveryResponse struct {
 	Issuer                            string   `json:"issuer"`
 	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
 	TokenEndpoint                     string   `json:"token_endpoint"`
+	DeviceAuthorizationEndpoint       string   `json:"device_authorization_endpoint,omitempty"`
 	UserinfoEndpoint                  string   `json:"userinfo_endpoint"`
 	RevocationEndpoint                string   `json:"revocation_endpoint"`
 	JwksURI                           string   `json:"jwks_uri"`

--- a/mocks/github.com/int128/kubelogin/pkg/oidc/client_mock/mocks.go
+++ b/mocks/github.com/int128/kubelogin/pkg/oidc/client_mock/mocks.go
@@ -111,8 +111,8 @@ func (_c *MockInterface_ExchangeAuthCode_Call) RunAndReturn(run func(ctx context
 }
 
 // ExchangeDeviceCode provides a mock function for the type MockInterface
-func (_mock *MockInterface) ExchangeDeviceCode(ctx context.Context, authResponse *oauth2dev.AuthorizationResponse) (*oidc.TokenSet, error) {
-	ret := _mock.Called(ctx, authResponse)
+func (_mock *MockInterface) ExchangeDeviceCode(ctx context.Context, authResponse *oauth2dev.AuthorizationResponse, pkceParams pkce.Params) (*oidc.TokenSet, error) {
+	ret := _mock.Called(ctx, authResponse, pkceParams)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ExchangeDeviceCode")
@@ -120,18 +120,18 @@ func (_mock *MockInterface) ExchangeDeviceCode(ctx context.Context, authResponse
 
 	var r0 *oidc.TokenSet
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *oauth2dev.AuthorizationResponse) (*oidc.TokenSet, error)); ok {
-		return returnFunc(ctx, authResponse)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *oauth2dev.AuthorizationResponse, pkce.Params) (*oidc.TokenSet, error)); ok {
+		return returnFunc(ctx, authResponse, pkceParams)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *oauth2dev.AuthorizationResponse) *oidc.TokenSet); ok {
-		r0 = returnFunc(ctx, authResponse)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *oauth2dev.AuthorizationResponse, pkce.Params) *oidc.TokenSet); ok {
+		r0 = returnFunc(ctx, authResponse, pkceParams)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*oidc.TokenSet)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, *oauth2dev.AuthorizationResponse) error); ok {
-		r1 = returnFunc(ctx, authResponse)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *oauth2dev.AuthorizationResponse, pkce.Params) error); ok {
+		r1 = returnFunc(ctx, authResponse, pkceParams)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -146,11 +146,12 @@ type MockInterface_ExchangeDeviceCode_Call struct {
 // ExchangeDeviceCode is a helper method to define mock.On call
 //   - ctx context.Context
 //   - authResponse *oauth2dev.AuthorizationResponse
-func (_e *MockInterface_Expecter) ExchangeDeviceCode(ctx any, authResponse any) *MockInterface_ExchangeDeviceCode_Call {
-	return &MockInterface_ExchangeDeviceCode_Call{Call: _e.mock.On("ExchangeDeviceCode", ctx, authResponse)}
+//   - pkceParams pkce.Params
+func (_e *MockInterface_Expecter) ExchangeDeviceCode(ctx any, authResponse any, pkceParams any) *MockInterface_ExchangeDeviceCode_Call {
+	return &MockInterface_ExchangeDeviceCode_Call{Call: _e.mock.On("ExchangeDeviceCode", ctx, authResponse, pkceParams)}
 }
 
-func (_c *MockInterface_ExchangeDeviceCode_Call) Run(run func(ctx context.Context, authResponse *oauth2dev.AuthorizationResponse)) *MockInterface_ExchangeDeviceCode_Call {
+func (_c *MockInterface_ExchangeDeviceCode_Call) Run(run func(ctx context.Context, authResponse *oauth2dev.AuthorizationResponse, pkceParams pkce.Params)) *MockInterface_ExchangeDeviceCode_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -160,9 +161,14 @@ func (_c *MockInterface_ExchangeDeviceCode_Call) Run(run func(ctx context.Contex
 		if args[1] != nil {
 			arg1 = args[1].(*oauth2dev.AuthorizationResponse)
 		}
+		var arg2 pkce.Params
+		if args[2] != nil {
+			arg2 = args[2].(pkce.Params)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -173,7 +179,7 @@ func (_c *MockInterface_ExchangeDeviceCode_Call) Return(tokenSet *oidc.TokenSet,
 	return _c
 }
 
-func (_c *MockInterface_ExchangeDeviceCode_Call) RunAndReturn(run func(ctx context.Context, authResponse *oauth2dev.AuthorizationResponse) (*oidc.TokenSet, error)) *MockInterface_ExchangeDeviceCode_Call {
+func (_c *MockInterface_ExchangeDeviceCode_Call) RunAndReturn(run func(ctx context.Context, authResponse *oauth2dev.AuthorizationResponse, pkceParams pkce.Params) (*oidc.TokenSet, error)) *MockInterface_ExchangeDeviceCode_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -230,8 +236,8 @@ func (_c *MockInterface_GetAuthCodeURL_Call) RunAndReturn(run func(in client.Aut
 }
 
 // GetDeviceAuthorization provides a mock function for the type MockInterface
-func (_mock *MockInterface) GetDeviceAuthorization(ctx context.Context) (*oauth2dev.AuthorizationResponse, error) {
-	ret := _mock.Called(ctx)
+func (_mock *MockInterface) GetDeviceAuthorization(ctx context.Context, pkceParams pkce.Params) (*oauth2dev.AuthorizationResponse, error) {
+	ret := _mock.Called(ctx, pkceParams)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetDeviceAuthorization")
@@ -239,18 +245,18 @@ func (_mock *MockInterface) GetDeviceAuthorization(ctx context.Context) (*oauth2
 
 	var r0 *oauth2dev.AuthorizationResponse
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context) (*oauth2dev.AuthorizationResponse, error)); ok {
-		return returnFunc(ctx)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, pkce.Params) (*oauth2dev.AuthorizationResponse, error)); ok {
+		return returnFunc(ctx, pkceParams)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context) *oauth2dev.AuthorizationResponse); ok {
-		r0 = returnFunc(ctx)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, pkce.Params) *oauth2dev.AuthorizationResponse); ok {
+		r0 = returnFunc(ctx, pkceParams)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*oauth2dev.AuthorizationResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = returnFunc(ctx)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, pkce.Params) error); ok {
+		r1 = returnFunc(ctx, pkceParams)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -264,18 +270,24 @@ type MockInterface_GetDeviceAuthorization_Call struct {
 
 // GetDeviceAuthorization is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockInterface_Expecter) GetDeviceAuthorization(ctx any) *MockInterface_GetDeviceAuthorization_Call {
-	return &MockInterface_GetDeviceAuthorization_Call{Call: _e.mock.On("GetDeviceAuthorization", ctx)}
+//   - pkceParams pkce.Params
+func (_e *MockInterface_Expecter) GetDeviceAuthorization(ctx any, pkceParams any) *MockInterface_GetDeviceAuthorization_Call {
+	return &MockInterface_GetDeviceAuthorization_Call{Call: _e.mock.On("GetDeviceAuthorization", ctx, pkceParams)}
 }
 
-func (_c *MockInterface_GetDeviceAuthorization_Call) Run(run func(ctx context.Context)) *MockInterface_GetDeviceAuthorization_Call {
+func (_c *MockInterface_GetDeviceAuthorization_Call) Run(run func(ctx context.Context, pkceParams pkce.Params)) *MockInterface_GetDeviceAuthorization_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
+		var arg1 pkce.Params
+		if args[1] != nil {
+			arg1 = args[1].(pkce.Params)
+		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -286,7 +298,7 @@ func (_c *MockInterface_GetDeviceAuthorization_Call) Return(authorizationRespons
 	return _c
 }
 
-func (_c *MockInterface_GetDeviceAuthorization_Call) RunAndReturn(run func(ctx context.Context) (*oauth2dev.AuthorizationResponse, error)) *MockInterface_GetDeviceAuthorization_Call {
+func (_c *MockInterface_GetDeviceAuthorization_Call) RunAndReturn(run func(ctx context.Context, pkceParams pkce.Params) (*oauth2dev.AuthorizationResponse, error)) *MockInterface_GetDeviceAuthorization_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/oidc/client/client.go
+++ b/pkg/oidc/client/client.go
@@ -22,8 +22,8 @@ type Interface interface {
 	NegotiatedPKCEMethod() pkce.Method
 	GetTokenByROPC(ctx context.Context, username, password string) (*oidc.TokenSet, error)
 	GetTokenByClientCredentials(ctx context.Context, in GetTokenByClientCredentialsInput) (*oidc.TokenSet, error)
-	GetDeviceAuthorization(ctx context.Context) (*oauth2dev.AuthorizationResponse, error)
-	ExchangeDeviceCode(ctx context.Context, authResponse *oauth2dev.AuthorizationResponse) (*oidc.TokenSet, error)
+	GetDeviceAuthorization(ctx context.Context, pkceParams pkce.Params) (*oauth2dev.AuthorizationResponse, error)
+	ExchangeDeviceCode(ctx context.Context, authResponse *oauth2dev.AuthorizationResponse, pkceParams pkce.Params) (*oidc.TokenSet, error)
 	Refresh(ctx context.Context, refreshToken string) (*oidc.TokenSet, error)
 }
 

--- a/pkg/oidc/client/devicecode.go
+++ b/pkg/oidc/client/devicecode.go
@@ -5,26 +5,59 @@ import (
 	"fmt"
 
 	"github.com/int128/kubelogin/pkg/oidc"
+	"github.com/int128/kubelogin/pkg/pkce"
 	"github.com/int128/oauth2dev"
 	"golang.org/x/oauth2"
 )
 
-// GetDeviceAuthorization initializes the device authorization code challenge
-func (c *client) GetDeviceAuthorization(ctx context.Context) (*oauth2dev.AuthorizationResponse, error) {
+// GetDeviceAuthorization initializes the device authorization code challenge.
+// If pkceParams has a method set, the PKCE code challenge is included in the request.
+func (c *client) GetDeviceAuthorization(ctx context.Context, pkceParams pkce.Params) (*oauth2dev.AuthorizationResponse, error) {
 	ctx = c.wrapContext(ctx)
-	config := c.oauth2Config
-	config.Endpoint = oauth2.Endpoint{
-		AuthURL: c.provider.Endpoint().DeviceAuthURL,
+	if pkceParams.Method == pkce.NoMethod {
+		config := c.oauth2Config
+		config.Endpoint = oauth2.Endpoint{
+			AuthURL: c.provider.Endpoint().DeviceAuthURL,
+		}
+		return oauth2dev.RetrieveCode(ctx, config)
 	}
-	return oauth2dev.RetrieveCode(ctx, config)
+	// Use the stdlib DeviceAuth which supports AuthCodeOptions (e.g. PKCE challenge).
+	// c.oauth2Config already has Endpoint.DeviceAuthURL set from the factory.
+	da, err := c.oauth2Config.DeviceAuth(ctx, pkceParams.AuthCodeOption())
+	if err != nil {
+		return nil, err
+	}
+	return &oauth2dev.AuthorizationResponse{
+		DeviceCode:              da.DeviceCode,
+		UserCode:                da.UserCode,
+		VerificationURI:         da.VerificationURI,
+		VerificationURIComplete: da.VerificationURIComplete,
+		Interval:                int(da.Interval),
+	}, nil
 }
 
-// ExchangeDeviceCode exchanges the device authorization code for an oidc.TokenSet
-func (c *client) ExchangeDeviceCode(ctx context.Context, authResponse *oauth2dev.AuthorizationResponse) (*oidc.TokenSet, error) {
+// ExchangeDeviceCode exchanges the device authorization code for an oidc.TokenSet.
+// If pkceParams has a method set, the PKCE code verifier is included in the token request.
+func (c *client) ExchangeDeviceCode(ctx context.Context, authResponse *oauth2dev.AuthorizationResponse, pkceParams pkce.Params) (*oidc.TokenSet, error) {
 	ctx = c.wrapContext(ctx)
-	tokenResponse, err := oauth2dev.PollToken(ctx, c.oauth2Config, *authResponse)
+	var (
+		token *oauth2.Token
+		err   error
+	)
+	if pkceParams.Method == pkce.NoMethod {
+		token, err = oauth2dev.PollToken(ctx, c.oauth2Config, *authResponse)
+	} else {
+		da := &oauth2.DeviceAuthResponse{
+			DeviceCode:              authResponse.DeviceCode,
+			UserCode:                authResponse.UserCode,
+			VerificationURI:         authResponse.VerificationURI,
+			VerificationURIComplete: authResponse.VerificationURIComplete,
+			Interval:                int64(authResponse.Interval),
+		}
+		token, err = c.oauth2Config.DeviceAccessToken(ctx, da, pkceParams.TokenRequestOption())
+	}
 	if err != nil {
 		return nil, fmt.Errorf("device-code: exchange failed: %w", err)
 	}
-	return c.verifyToken(ctx, tokenResponse, "")
+	return c.verifyToken(ctx, token, "")
 }

--- a/pkg/usecases/authentication/devicecode/devicecode.go
+++ b/pkg/usecases/authentication/devicecode/devicecode.go
@@ -8,7 +8,9 @@ import (
 	"github.com/int128/kubelogin/pkg/infrastructure/logger"
 	"github.com/int128/kubelogin/pkg/oidc"
 	"github.com/int128/kubelogin/pkg/oidc/client"
+	"github.com/int128/kubelogin/pkg/pkce"
 )
+
 
 type Option struct {
 	SkipOpenBrowser bool
@@ -24,7 +26,12 @@ type DeviceCode struct {
 func (u *DeviceCode) Do(ctx context.Context, in *Option, oidcClient client.Interface) (*oidc.TokenSet, error) {
 	u.Logger.V(1).Infof("starting the oauth2 device code flow")
 
-	authResponse, err := oidcClient.GetDeviceAuthorization(ctx)
+	pkceParams, err := pkce.New(oidcClient.NegotiatedPKCEMethod())
+	if err != nil {
+		return nil, fmt.Errorf("could not generate the PKCE parameters: %w", err)
+	}
+
+	authResponse, err := oidcClient.GetDeviceAuthorization(ctx, pkceParams)
 	if err != nil {
 		return nil, fmt.Errorf("authorization error: %w", err)
 	}
@@ -41,7 +48,7 @@ func (u *DeviceCode) Do(ctx context.Context, in *Option, oidcClient client.Inter
 		return nil, fmt.Errorf("no verification URI in the authorization response")
 	}
 
-	tokenSet, err := oidcClient.ExchangeDeviceCode(ctx, authResponse)
+	tokenSet, err := oidcClient.ExchangeDeviceCode(ctx, authResponse, pkceParams)
 	u.Logger.V(1).Infof("finished the oauth2 device code flow")
 	if err != nil {
 		return nil, fmt.Errorf("unable to exchange device code: %w", err)

--- a/pkg/usecases/authentication/devicecode/devicecode_test.go
+++ b/pkg/usecases/authentication/devicecode/devicecode_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/int128/kubelogin/mocks/github.com/int128/kubelogin/pkg/infrastructure/browser_mock"
 	"github.com/int128/kubelogin/mocks/github.com/int128/kubelogin/pkg/oidc/client_mock"
 	"github.com/int128/kubelogin/pkg/oidc"
+	"github.com/int128/kubelogin/pkg/pkce"
 	"github.com/int128/kubelogin/pkg/testing/logger"
 	"github.com/int128/oauth2dev"
 	"github.com/stretchr/testify/mock"
@@ -15,6 +16,7 @@ import (
 
 func TestDeviceCode(t *testing.T) {
 	ctx := context.TODO()
+	noPKCE := pkce.Params{}
 
 	t.Run("Authorization error", func(t *testing.T) {
 		mockClient := client_mock.NewMockInterface(t)
@@ -23,7 +25,8 @@ func TestDeviceCode(t *testing.T) {
 			Logger:  logger.New(t),
 		}
 		errTest := errors.New("test error")
-		mockClient.EXPECT().GetDeviceAuthorization(ctx).Return(nil, errTest).Once()
+		mockClient.EXPECT().NegotiatedPKCEMethod().Return(pkce.NoMethod).Once()
+		mockClient.EXPECT().GetDeviceAuthorization(ctx, noPKCE).Return(nil, errTest).Once()
 		_, err := dc.Do(ctx, &Option{}, mockClient)
 		if !errors.Is(err, errTest) {
 			t.Errorf("returned error is not the test error: %v", err)
@@ -43,14 +46,15 @@ func TestDeviceCode(t *testing.T) {
 			ExpiresIn:               2,
 			Interval:                1,
 		}
-		mockClient.EXPECT().GetDeviceAuthorization(ctx).Return(&oauth2dev.AuthorizationResponse{
+		mockClient.EXPECT().NegotiatedPKCEMethod().Return(pkce.NoMethod).Once()
+		mockClient.EXPECT().GetDeviceAuthorization(ctx, noPKCE).Return(&oauth2dev.AuthorizationResponse{
 			Interval:                1,
 			ExpiresIn:               2,
 			VerificationURIComplete: "https://example.com/verificationComplete?code=code123",
 			DeviceCode:              "device-code-1",
 		}, nil).Once()
 		mockBrowser.EXPECT().Open("https://example.com/verificationComplete?code=code123").Return(nil).Once()
-		mockClient.EXPECT().ExchangeDeviceCode(mock.Anything, mockResponse).Return(&oidc.TokenSet{
+		mockClient.EXPECT().ExchangeDeviceCode(mock.Anything, mockResponse, noPKCE).Return(&oidc.TokenSet{
 			IDToken: "test-id-token",
 		}, nil).Once()
 		ts, err := dc.Do(ctx, &Option{}, mockClient)
@@ -75,14 +79,15 @@ func TestDeviceCode(t *testing.T) {
 			ExpiresIn:       2,
 			Interval:        1,
 		}
-		mockClient.EXPECT().GetDeviceAuthorization(ctx).Return(&oauth2dev.AuthorizationResponse{
+		mockClient.EXPECT().NegotiatedPKCEMethod().Return(pkce.NoMethod).Once()
+		mockClient.EXPECT().GetDeviceAuthorization(ctx, noPKCE).Return(&oauth2dev.AuthorizationResponse{
 			Interval:        1,
 			ExpiresIn:       2,
 			VerificationURI: "https://example.com/verificationComplete",
 			DeviceCode:      "device-code-1",
 		}, nil).Once()
 		mockBrowser.EXPECT().Open("https://example.com/verificationComplete").Return(nil).Once()
-		mockClient.EXPECT().ExchangeDeviceCode(mock.Anything, mockResponseWithoutComplete).Return(&oidc.TokenSet{
+		mockClient.EXPECT().ExchangeDeviceCode(mock.Anything, mockResponseWithoutComplete, noPKCE).Return(&oidc.TokenSet{
 			IDToken: "test-id-token",
 		}, nil).Once()
 		ts, err := dc.Do(ctx, &Option{}, mockClient)
@@ -107,9 +112,10 @@ func TestDeviceCode(t *testing.T) {
 			ExpiresIn:       2,
 			Interval:        1,
 		}
-		mockClient.EXPECT().GetDeviceAuthorization(ctx).Return(mockResponse, nil).Once()
+		mockClient.EXPECT().NegotiatedPKCEMethod().Return(pkce.NoMethod).Once()
+		mockClient.EXPECT().GetDeviceAuthorization(ctx, noPKCE).Return(mockResponse, nil).Once()
 		mockBrowser.EXPECT().Open("https://example.com/verificationCompleteURL").Return(nil).Once()
-		mockClient.EXPECT().ExchangeDeviceCode(mock.Anything, mockResponse).Return(&oidc.TokenSet{
+		mockClient.EXPECT().ExchangeDeviceCode(mock.Anything, mockResponse, noPKCE).Return(&oidc.TokenSet{
 			IDToken: "test-id-token",
 		}, nil).Once()
 		ts, err := dc.Do(ctx, &Option{}, mockClient)
@@ -134,14 +140,15 @@ func TestDeviceCode(t *testing.T) {
 			ExpiresIn:               2,
 			Interval:                1,
 		}
-		mockClient.EXPECT().GetDeviceAuthorization(ctx).Return(&oauth2dev.AuthorizationResponse{
+		mockClient.EXPECT().NegotiatedPKCEMethod().Return(pkce.NoMethod).Once()
+		mockClient.EXPECT().GetDeviceAuthorization(ctx, noPKCE).Return(&oauth2dev.AuthorizationResponse{
 			Interval:                1,
 			ExpiresIn:               2,
 			VerificationURIComplete: "https://example.com/verificationComplete?code=code123",
 			DeviceCode:              "device-code-1",
 		}, nil).Once()
 		mockBrowser.EXPECT().Open("https://example.com/verificationComplete?code=code123").Return(nil).Once()
-		mockClient.EXPECT().ExchangeDeviceCode(mock.Anything, mockResponse).Return(nil, errors.New("test error")).Once()
+		mockClient.EXPECT().ExchangeDeviceCode(mock.Anything, mockResponse, noPKCE).Return(nil, errors.New("test error")).Once()
 		_, err := dc.Do(ctx, &Option{}, mockClient)
 		if err == nil {
 			t.Errorf("did not return error: %v", err)


### PR DESCRIPTION
Closes #1470.

Some authorization servers (e.g. Keycloak, see https://github.com/keycloak/keycloak/issues/9710) support PKCE on the device authorization grant. 
Also in Keycloak in Client could support both Authorization Code and Device Code grants and require PKCE then. In this case the device code grant will need to support PKCE aswell.

This PR adds support for it in kubelogin.
I've tested it with our Keycloak setup and it works just fine like this.

Notable Changes:

- **PKCE is used by default**: Same behavior as for the auth code flow where auto enables PKCE when the server advertises it, device code follows the same auto behaviour. If the server advertises `code_challenge_methods_supported: [S256]` in its discovery document, PKCE is used automatically. The user has to pass `--oidc-pkce-method no` to disable it explicitly.
- The `code_challenge` / `code_challenge_method` parameters are added to the device authorization request, and `code_verifier` is added to the token request, using the existing golang.org/x/oauth2 device flow primitives.
- Integration test added covering both the non-PKCE and PKCE device code paths against a local test OIDC server that verifies the S256 challenge.