### PR TITLE
Add --client-credentials-auth-style to control how client credentials are sent

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,6 +32,7 @@ Flags:
       --local-server-key string                         [authcode] Certificate key path for the local server
       --open-url-after-authentication string            [authcode] If set, open the URL in the browser after authentication
       --oidc-auth-request-extra-params stringToString   [authcode, authcode-keyboard, client-credentials] Extra query parameters to send with an authentication request (default [])
+      --client-credentials-auth-style                    [client-credentials] Auth style for sending client credentials. header (HTTP Basic Auth) or parameters (Request Body)
       --username string                                 [password] Username for resource owner password credentials grant
       --password string                                 [password] Password for resource owner password credentials grant
   -h, --help                                            help for get-token

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,7 +32,7 @@ Flags:
       --local-server-key string                         [authcode] Certificate key path for the local server
       --open-url-after-authentication string            [authcode] If set, open the URL in the browser after authentication
       --oidc-auth-request-extra-params stringToString   [authcode, authcode-keyboard, client-credentials] Extra query parameters to send with an authentication request (default [])
-      --client-credentials-auth-style                    [client-credentials] Auth style for sending client credentials. header (HTTP Basic Auth) or parameters (Request Body)
+      --client-credentials-auth-style                   [client-credentials] Auth style for sending client credentials. header (HTTP Basic Auth), parameters (Request Body) or auto for auto detection
       --username string                                 [password] Username for resource owner password credentials grant
       --password string                                 [password] Password for resource owner password credentials grant
   -h, --help                                            help for get-token

--- a/pkg/cmd/authentication.go
+++ b/pkg/cmd/authentication.go
@@ -49,7 +49,7 @@ func (o *authenticationOptions) addFlags(f *pflag.FlagSet) {
 	f.StringVar(&o.LocalServerKeyFile, "local-server-key", "", "[authcode] Certificate key path for the local server")
 	f.StringVar(&o.OpenURLAfterAuthentication, "open-url-after-authentication", "", "[authcode] If set, open the URL in the browser after authentication")
 	f.StringToStringVar(&o.AuthRequestExtraParams, "oidc-auth-request-extra-params", nil, "[authcode, authcode-keyboard, client-credentials] Extra query parameters to send with an authentication request")
-	f.StringVar(&o.ClientCredentialsAuthStyle, "client-credentials-auth-style", "auto", "[client-credentials] Auth style for sending client credentials. header (HTTP Basic Auth) or parameters (Request Body)")
+	f.StringVar(&o.ClientCredentialsAuthStyle, "client-credentials-auth-style", "header", "[client-credentials] Auth style for sending client credentials. header (HTTP Basic Auth), parameters (Request Body) or auto for auto detection")
 	f.StringVar(&o.Username, "username", "", "[password] Username for resource owner password credentials grant")
 	f.StringVar(&o.Password, "password", "", "[password] Password for resource owner password credentials grant")
 }

--- a/pkg/cmd/authentication.go
+++ b/pkg/cmd/authentication.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
+	"golang.org/x/oauth2"
 
 	"github.com/int128/kubelogin/pkg/oidc/client"
 	"github.com/int128/kubelogin/pkg/usecases/authentication"
@@ -24,6 +25,7 @@ type authenticationOptions struct {
 	LocalServerKeyFile         string
 	OpenURLAfterAuthentication string
 	AuthRequestExtraParams     map[string]string
+	ClientCredentialsAuthStyle string
 	Username                   string
 	Password                   string
 }
@@ -47,6 +49,7 @@ func (o *authenticationOptions) addFlags(f *pflag.FlagSet) {
 	f.StringVar(&o.LocalServerKeyFile, "local-server-key", "", "[authcode] Certificate key path for the local server")
 	f.StringVar(&o.OpenURLAfterAuthentication, "open-url-after-authentication", "", "[authcode] If set, open the URL in the browser after authentication")
 	f.StringToStringVar(&o.AuthRequestExtraParams, "oidc-auth-request-extra-params", nil, "[authcode, authcode-keyboard, client-credentials] Extra query parameters to send with an authentication request")
+	f.StringVar(&o.ClientCredentialsAuthStyle, "client-credentials-auth-style", "auto", "[client-credentials] Auth style for sending client credentials. header (HTTP Basic Auth) or parameters (Request Body)")
 	f.StringVar(&o.Username, "username", "", "[password] Username for resource owner password credentials grant")
 	f.StringVar(&o.Password, "password", "", "[password] Password for resource owner password credentials grant")
 }
@@ -84,11 +87,23 @@ func (o *authenticationOptions) grantOptionSet() (s authentication.GrantOptionSe
 			BrowserCommand:  o.BrowserCommand,
 		}
 	case o.GrantType == "client-credentials":
+		var authStyle oauth2.AuthStyle
 		endpointparams := make(map[string][]string, len(o.AuthRequestExtraParams))
 		for k, v := range o.AuthRequestExtraParams {
 			endpointparams[k] = []string{v}
 		}
-		s.ClientCredentialsOption = &client.GetTokenByClientCredentialsInput{EndpointParams: endpointparams}
+
+		if o.ClientCredentialsAuthStyle == "header" {
+			authStyle = oauth2.AuthStyleInHeader
+		}
+		if o.ClientCredentialsAuthStyle == "parameter" {
+			authStyle = oauth2.AuthStyleInParams
+		}
+		if o.ClientCredentialsAuthStyle == "auto" {
+			authStyle = oauth2.AuthStyleAutoDetect
+		}
+
+		s.ClientCredentialsOption = &client.GetTokenByClientCredentialsInput{EndpointParams: endpointparams, AuthStyle: authStyle}
 	default:
 		err = fmt.Errorf("grant-type must be one of (%s)", allGrantType)
 	}

--- a/pkg/cmd/authentication_test.go
+++ b/pkg/cmd/authentication_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/int128/kubelogin/pkg/usecases/authentication/authcode"
 	"github.com/int128/kubelogin/pkg/usecases/authentication/ropc"
 	"github.com/spf13/pflag"
+	"golang.org/x/oauth2"
 )
 
 func Test_authenticationOptions_grantOptionSet(t *testing.T) {
@@ -89,7 +90,7 @@ func Test_authenticationOptions_grantOptionSet(t *testing.T) {
 				},
 			},
 		},
-		"GrantType=client-credentials": {
+		"GrantType=client-credentials (default auth style)": {
 			args: []string{
 				"--grant-type", "client-credentials",
 				"--oidc-auth-request-extra-params", "audience=https://example.com/service1",
@@ -101,6 +102,37 @@ func Test_authenticationOptions_grantOptionSet(t *testing.T) {
 						"audience": []string{"https://example.com/service1"},
 						"jti":      []string{"myUUID"},
 					},
+					AuthStyle: oauth2.AuthStyleAutoDetect, // default is "auto"
+				},
+			},
+		},
+		"GrantType=client-credentials auth style header": {
+			args: []string{
+				"--grant-type", "client-credentials",
+				"--client-credentials-auth-style", "header",
+				"--oidc-auth-request-extra-params", "audience=https://example.com/service1",
+			},
+			want: authentication.GrantOptionSet{
+				ClientCredentialsOption: &client.GetTokenByClientCredentialsInput{
+					EndpointParams: map[string][]string{
+						"audience": []string{"https://example.com/service1"},
+					},
+					AuthStyle: oauth2.AuthStyleInHeader,
+				},
+			},
+		},
+		"GrantType=client-credentials auth style parameter": {
+			args: []string{
+				"--grant-type", "client-credentials",
+				"--client-credentials-auth-style", "parameter",
+				"--oidc-auth-request-extra-params", "audience=https://example.com/service1",
+			},
+			want: authentication.GrantOptionSet{
+				ClientCredentialsOption: &client.GetTokenByClientCredentialsInput{
+					EndpointParams: map[string][]string{
+						"audience": []string{"https://example.com/service1"},
+					},
+					AuthStyle: oauth2.AuthStyleInParams,
 				},
 			},
 		},

--- a/pkg/cmd/authentication_test.go
+++ b/pkg/cmd/authentication_test.go
@@ -102,7 +102,7 @@ func Test_authenticationOptions_grantOptionSet(t *testing.T) {
 						"audience": []string{"https://example.com/service1"},
 						"jti":      []string{"myUUID"},
 					},
-					AuthStyle: oauth2.AuthStyleAutoDetect, // default is "auto"
+					AuthStyle: oauth2.AuthStyleInHeader, // default is "auto"
 				},
 			},
 		},
@@ -121,10 +121,10 @@ func Test_authenticationOptions_grantOptionSet(t *testing.T) {
 				},
 			},
 		},
-		"GrantType=client-credentials auth style parameter": {
+		"GrantType=client-credentials auth style auto detection": {
 			args: []string{
 				"--grant-type", "client-credentials",
-				"--client-credentials-auth-style", "parameter",
+				"--client-credentials-auth-style", "auto",
 				"--oidc-auth-request-extra-params", "audience=https://example.com/service1",
 			},
 			want: authentication.GrantOptionSet{
@@ -132,7 +132,7 @@ func Test_authenticationOptions_grantOptionSet(t *testing.T) {
 					EndpointParams: map[string][]string{
 						"audience": []string{"https://example.com/service1"},
 					},
-					AuthStyle: oauth2.AuthStyleInParams,
+					AuthStyle: oauth2.AuthStyleAutoDetect,
 				},
 			},
 		},

--- a/pkg/oidc/client/clientcredentials.go
+++ b/pkg/oidc/client/clientcredentials.go
@@ -11,6 +11,7 @@ import (
 
 type GetTokenByClientCredentialsInput struct {
 	EndpointParams map[string][]string
+	AuthStyle      oauth2.AuthStyle
 }
 
 // GetTokenByClientCredentials performs the client credentials flow.
@@ -24,7 +25,7 @@ func (c *client) GetTokenByClientCredentials(ctx context.Context, in GetTokenByC
 		TokenURL:       c.oauth2Config.Endpoint.TokenURL,
 		Scopes:         c.oauth2Config.Scopes,
 		EndpointParams: in.EndpointParams,
-		AuthStyle:      oauth2.AuthStyleInHeader,
+		AuthStyle:      in.AuthStyle,
 	}
 	source := config.TokenSource(ctx)
 	token, err := source.Token()


### PR DESCRIPTION
This PR makes the client-credentials OAuth2 flow configurable so users can choose how kubelogin sends client credentials to the token endpoint.

Some OAuth2 / OIDC token endpoints expect client credentials in the HTTP Authorization header (HTTP Basic), while others require client_id and client_secret be sent in the request body. Previously kubelogin always sent credentials in the Authorization header. Making the auth style configurable improves interoperability with different providers.

### **What changed**
**Add a new CLI flag:**
    
        --client-credentials-auth-style [auto|header|parameter] (default: header)
            auto — oauth2 library autodetects the style (AuthStyleAutoDetect)
            header — send credentials in the Authorization header (AuthStyleInHeader)
            parameter — send client_id/client_secret in the request body (AuthStyleInParams)

### Tests:
Extend pkg/cmd/authentication_test.go to assert that the flag maps to the correct AuthStyle values (auto/header/parameter).

### Docs:
README updated with a short section explaining the flag and examples.

