### PR TITLE
feat: implement rfc8693 tokenexchange

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -23,7 +23,7 @@ Flags:
       --tls-renegotiation-once                          If set, allow a remote server to request renegotiation once per connection
       --tls-renegotiation-freely                        If set, allow a remote server to repeatedly request renegotiation
       --oidc-pkce-method string                         PKCE code challenge method. Automatically determined by default. One of (auto|no|S256) (default "auto")
-      --grant-type string                               Authorization grant type to use. One of (auto|authcode|authcode-keyboard|password|device-code|client-credentials) (default "auto")
+      --grant-type string                               Authorization grant type to use. One of (auto|authcode|authcode-keyboard|password|device-code|client-credentials|token-exchange) (default "auto")
       --listen-address strings                          [authcode] Address to bind to the local server. If multiple addresses are set, it will try binding in order (default [127.0.0.1:8000,127.0.0.1:18000])
       --skip-open-browser                               [authcode] Do not open the browser automatically
       --browser-command string                          [authcode] Command to open the browser
@@ -31,9 +31,16 @@ Flags:
       --local-server-cert string                        [authcode] Certificate path for the local server
       --local-server-key string                         [authcode] Certificate key path for the local server
       --open-url-after-authentication string            [authcode] If set, open the URL in the browser after authentication
-      --oidc-auth-request-extra-params stringToString   [authcode, authcode-keyboard, client-credentials] Extra query parameters to send with an authentication request (default [])
+      --oidc-auth-request-extra-params stringToString   [authcode, authcode-keyboard, client-credentials, token-exchange] Extra query parameters to send with an authentication request (default [])
       --username string                                 [password] Username for resource owner password credentials grant
       --password string                                 [password] Password for resource owner password credentials grant
+      --token-exchange-resource strings                 [token-exchange] a URI for the target resource the client intends to use
+      --token-exchange-audience strings                 [token-exchange] the audience the client intends to use
+      --token-exchange-requested-token-type string      [token-exchange] return type desired in response, e.g. id-token or access-token
+      --token-exchange-subject-token string             [token-exchange] the token to exchange (required)
+      --token-exchange-subject-token-type string        [token-exchange] the type of token provided, e.g. id-token or access-token (required) (default "urn:ietf:params:oauth:token-type:access_token")
+      --token-exchange-actor-token string               [token-exchange] optional token for delegated access pattern
+      --token-exchange-actor-token-type string          [token-exchange] type of the actor token, e.g. id-token or access-token
   -h, --help                                            help for get-token
 
 Global Flags:
@@ -305,6 +312,20 @@ It performs the [OAuth 2.0 Client Credentials Flow](https://datatracker.ietf.org
 ```
 
 Per specification, this flow only returns authorization tokens.
+
+### Token Exchange
+
+It performs the [Token Exchange](https://datatracker.ietf.org/doc/html/rfc8693) when `--grant-type=token-exchange` is set.
+
+```yaml
+- --grant-type=toke-exchange
+```
+
+You need to explicitly set the subject token.
+
+```yaml
+- --subject-token=<subject_token>
+```
 
 ## Run in Docker
 

--- a/integration_test/oidcserver/handler/handler.go
+++ b/integration_test/oidcserver/handler/handler.go
@@ -143,6 +143,27 @@ func (h *Handlers) Exchange(w http.ResponseWriter, r *http.Request) {
 			if err := e.Encode(tokenResponse); err != nil {
 				return fmt.Errorf("could not render json: %w", err)
 			}
+		case "urn:ietf:params:oauth:grant-type:token-exchange":
+			// RFC 8693 Token Exchange
+			// https://datatracker.ietf.org/doc/html/rfc8693
+			tokenResponse, err := h.provider.AuthenticateTokenExchange(service.TokenExchangeRequest{
+				SubjectToken:     r.Form.Get("subject_token"),
+				SubjectTokenType: r.Form.Get("subject_token_type"),
+				ActorToken:       r.Form.Get("actor_token"),
+				ActorTokenType:   r.Form.Get("actor_token_type"),
+				Resource:         r.Form["resource"],
+				Audience:         r.Form["audience"],
+				RequestTokenType: r.Form.Get("requested_token_type"),
+				Scope:            r.Form.Get("scope"),
+			})
+			if err != nil {
+				return fmt.Errorf("token exchange error: %w", err)
+			}
+			w.Header().Add("Content-Type", "application/json")
+			e := json.NewEncoder(w)
+			if err := e.Encode(tokenResponse); err != nil {
+				return fmt.Errorf("could not render json: %w", err)
+			}
 		default:
 			// 5.2. Error Response
 			// https://tools.ietf.org/html/rfc6749#section-5.2

--- a/integration_test/oidcserver/service/service.go
+++ b/integration_test/oidcserver/service/service.go
@@ -159,6 +159,54 @@ func (svc *service) AuthenticatePassword(username, password, scope string) (*Tok
 	return resp, nil
 }
 
+func (svc *service) AuthenticateTokenExchange(req TokenExchangeRequest) (*TokenResponse, error) {
+	if req.SubjectToken == "" {
+		return nil, &ErrorResponse{Code: "invalid_request", Description: "subject_token is required"}
+	}
+	if req.SubjectTokenType == "" {
+		return nil, &ErrorResponse{Code: "invalid_request", Description: "subject_token_type is required"}
+	}
+	if req.ActorToken != "" && req.ActorTokenType == "" {
+		return nil, &ErrorResponse{Code: "invalid_request", Description: "actor_token_type is required when actor_token is set"}
+	}
+	if req.ActorToken == "" && req.ActorTokenType != "" {
+		return nil, &ErrorResponse{Code: "invalid_request", Description: "actor_token_type must not be set when actor_token is not set"}
+	}
+	if svc.config.Want.SubjectToken != "" && req.SubjectToken != svc.config.Want.SubjectToken {
+		svc.t.Errorf("subject_token wants `%s` but was `%s`", svc.config.Want.SubjectToken, req.SubjectToken)
+	}
+	if svc.config.Want.SubjectTokenType != "" && req.SubjectTokenType != svc.config.Want.SubjectTokenType {
+		svc.t.Errorf("subject_token_type wants `%s` but was `%s`", svc.config.Want.SubjectTokenType, req.SubjectTokenType)
+	}
+	if svc.config.Want.Scope != "" && req.Scope != svc.config.Want.Scope {
+		svc.t.Errorf("scope wants `%s` but was `%s`", svc.config.Want.Scope, req.Scope)
+	}
+	issuedTokenType := req.RequestTokenType
+	if issuedTokenType == "" {
+		issuedTokenType = "urn:ietf:params:oauth:token-type:access_token"
+	}
+	resp := &TokenResponse{
+		AccessToken:     "YOUR_ACCESS_TOKEN",
+		IssuedTokenType: issuedTokenType,
+		TokenType:       "Bearer",
+		ExpiresIn:       3600,
+
+		// RFC 8693 §2.2.1: A refresh token will typically not be issued when
+		// the exchange is of one temporary credential (the subject_token) for
+		// a different temporary credential (the issued token) ...
+		RefreshToken: "",
+		IDToken: testingJWT.EncodeF(svc.t, func(claims *testingJWT.Claims) {
+			claims.Issuer = svc.issuerURL
+			claims.Subject = "SUBJECT"
+			claims.IssuedAt = jwt.NewNumericDate(svc.config.Response.IDTokenExpiry.Add(-time.Hour))
+			claims.ExpiresAt = jwt.NewNumericDate(svc.config.Response.IDTokenExpiry)
+			claims.Audience = []string{"kubernetes"}
+		}),
+	}
+	svc.lastTokenResponse = resp
+	return resp, nil
+}
+
 func (svc *service) Refresh(refreshToken string) (*TokenResponse, error) {
 	if refreshToken != svc.config.Want.RefreshToken {
 		svc.t.Errorf("refreshToken wants %s but was %s", svc.config.Want.RefreshToken, refreshToken)

--- a/integration_test/oidcserver/service/types.go
+++ b/integration_test/oidcserver/service/types.go
@@ -28,6 +28,7 @@ type Provider interface {
 	AuthenticateCode(req AuthenticationRequest) (code string, err error)
 	Exchange(req TokenRequest) (*TokenResponse, error)
 	AuthenticatePassword(username, password, scope string) (*TokenResponse, error)
+	AuthenticateTokenExchange(req TokenExchangeRequest) (*TokenResponse, error)
 	Refresh(refreshToken string) (*TokenResponse, error)
 }
 
@@ -85,14 +86,29 @@ type TokenRequest struct {
 	CodeVerifier string
 }
 
+// TokenExchangeRequest represents the parameters of an OAuth 2.0 token exchange
+// request as defined in RFC 8693 section 2.1
+// https://datatracker.ietf.org/doc/html/rfc8693#name-request
+type TokenExchangeRequest struct {
+	SubjectToken     string
+	SubjectTokenType string
+	ActorToken       string
+	ActorTokenType   string
+	Resource         []string
+	Audience         []string
+	RequestTokenType string
+	Scope            string
+}
+
 // TokenResponse represents the type of:
 // https://openid.net/specs/openid-connect-core-1_0.html#TokenResponse
 type TokenResponse struct {
-	AccessToken  string `json:"access_token"`
-	TokenType    string `json:"token_type"`
-	RefreshToken string `json:"refresh_token"`
-	ExpiresIn    int    `json:"expires_in"`
-	IDToken      string `json:"id_token"`
+	AccessToken     string `json:"access_token"`
+	IssuedTokenType string `json:"issued_token_type,omitempty"` // optional (token-exchange)
+	TokenType       string `json:"token_type"`
+	RefreshToken    string `json:"refresh_token"`
+	ExpiresIn       int    `json:"expires_in"`
+	IDToken         string `json:"id_token"`
 }
 
 // ErrorResponse represents the error response described in the following section:

--- a/integration_test/oidcserver/testconfig/types.go
+++ b/integration_test/oidcserver/testconfig/types.go
@@ -11,6 +11,8 @@ type Want struct {
 	Username            string            // optional
 	Password            string            // optional
 	RefreshToken        string            // optional
+	SubjectToken        string            // optional (token-exchange)
+	SubjectTokenType    string            // optional (token-exchange)
 }
 
 // Response represents a set of response values.

--- a/integration_test/standalone_test.go
+++ b/integration_test/standalone_test.go
@@ -197,6 +197,107 @@ func TestStandalone(t *testing.T) {
 					})
 				})
 			})
+
+			t.Run("TokenExchange", func(t *testing.T) {
+				t.Parallel()
+				ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+				defer cancel()
+				sv := oidcserver.New(t, tc.keyPair, testconfig.Config{
+					Want: testconfig.Want{
+						SubjectToken:     "SUBJECT_TOKEN",
+						SubjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+					},
+					Response: testconfig.Response{
+						IDTokenExpiry: now.Add(time.Hour),
+					},
+				})
+				kubeConfigFilename := kubeconfig.Create(t, &kubeconfig.Values{
+					Issuer:                  sv.IssuerURL(),
+					IDPCertificateAuthority: tc.keyPair.CACertPath,
+				})
+				runStandalone(t, ctx, standaloneConfig{
+					issuerURL:          sv.IssuerURL(),
+					kubeConfigFilename: kubeConfigFilename,
+					httpDriver:         httpdriver.Zero(t),
+					now:                now,
+					args: []string{
+						"--token-exchange-subject-token", "SUBJECT_TOKEN",
+						"--token-exchange-subject-token-type", "urn:ietf:params:oauth:token-type:access_token",
+					},
+				})
+				kubeconfig.Verify(t, kubeConfigFilename, kubeconfig.AuthProviderConfig{
+					IDToken:      sv.LastTokenResponse().IDToken,
+					RefreshToken: "",
+				})
+			})
+			t.Run("TokenExchangeWithActor", func(t *testing.T) {
+				t.Parallel()
+				ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+				defer cancel()
+				sv := oidcserver.New(t, tc.keyPair, testconfig.Config{
+					Want: testconfig.Want{
+						SubjectToken:     "SUBJECT_TOKEN",
+						SubjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+					},
+					Response: testconfig.Response{
+						IDTokenExpiry: now.Add(time.Hour),
+					},
+				})
+				kubeConfigFilename := kubeconfig.Create(t, &kubeconfig.Values{
+					Issuer:                  sv.IssuerURL(),
+					IDPCertificateAuthority: tc.keyPair.CACertPath,
+				})
+				runStandalone(t, ctx, standaloneConfig{
+					issuerURL:          sv.IssuerURL(),
+					kubeConfigFilename: kubeConfigFilename,
+					httpDriver:         httpdriver.Zero(t),
+					now:                now,
+					args: []string{
+						"--token-exchange-subject-token", "SUBJECT_TOKEN",
+						"--token-exchange-subject-token-type", "urn:ietf:params:oauth:token-type:access_token",
+						"--token-exchange-actor-token", "ACTOR_TOKEN",
+						"--token-exchange-actor-token-type", "urn:ietf:params:oauth:token-type:access_token",
+					},
+				})
+				kubeconfig.Verify(t, kubeConfigFilename, kubeconfig.AuthProviderConfig{
+					IDToken:      sv.LastTokenResponse().IDToken,
+					RefreshToken: "",
+				})
+			})
+			t.Run("TokenExchangeExtraScopes", func(t *testing.T) {
+				t.Parallel()
+				ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+				defer cancel()
+				sv := oidcserver.New(t, tc.keyPair, testconfig.Config{
+					Want: testconfig.Want{
+						SubjectToken:     "SUBJECT_TOKEN",
+						SubjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+						Scope:            "profile groups openid",
+					},
+					Response: testconfig.Response{
+						IDTokenExpiry: now.Add(time.Hour),
+					},
+				})
+				kubeConfigFilename := kubeconfig.Create(t, &kubeconfig.Values{
+					Issuer:                  sv.IssuerURL(),
+					IDPCertificateAuthority: tc.keyPair.CACertPath,
+					ExtraScopes:             "profile,groups",
+				})
+				runStandalone(t, ctx, standaloneConfig{
+					issuerURL:          sv.IssuerURL(),
+					kubeConfigFilename: kubeConfigFilename,
+					httpDriver:         httpdriver.Zero(t),
+					now:                now,
+					args: []string{
+						"--token-exchange-subject-token", "SUBJECT_TOKEN",
+						"--token-exchange-subject-token-type", "urn:ietf:params:oauth:token-type:access_token",
+					},
+				})
+				kubeconfig.Verify(t, kubeConfigFilename, kubeconfig.AuthProviderConfig{
+					IDToken:      sv.LastTokenResponse().IDToken,
+					RefreshToken: "",
+				})
+			})
 		})
 	}
 

--- a/mocks/github.com/int128/kubelogin/pkg/oidc/client_mock/mocks.go
+++ b/mocks/github.com/int128/kubelogin/pkg/oidc/client_mock/mocks.go
@@ -461,6 +461,18 @@ func (_mock *MockInterface) GetTokenByROPC(ctx context.Context, username string,
 	return r0, r1
 }
 
+// GetTokenByTokenExchage provides a mock function for the type MockInterface
+func (_mock *MockInterface) GetTokenByTokenExchange(ctx context.Context, in client.GetTokenByTokenExchangeInput) (*oidc.TokenSet, error) {
+	// TODO(vdbe): implement this
+	ret := _mock.Called(ctx, in)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTokenByAuthCode")
+	}
+
+	panic("`GetTokenByTokenExchange` not yet implemented")
+}
+
 // MockInterface_GetTokenByROPC_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTokenByROPC'
 type MockInterface_GetTokenByROPC_Call struct {
 	*mock.Call

--- a/mocks/github.com/int128/kubelogin/pkg/oidc/client_mock/mocks.go
+++ b/mocks/github.com/int128/kubelogin/pkg/oidc/client_mock/mocks.go
@@ -461,18 +461,6 @@ func (_mock *MockInterface) GetTokenByROPC(ctx context.Context, username string,
 	return r0, r1
 }
 
-// GetTokenByTokenExchage provides a mock function for the type MockInterface
-func (_mock *MockInterface) GetTokenByTokenExchange(ctx context.Context, in client.GetTokenByTokenExchangeInput) (*oidc.TokenSet, error) {
-	// TODO(vdbe): implement this
-	ret := _mock.Called(ctx, in)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetTokenByAuthCode")
-	}
-
-	panic("`GetTokenByTokenExchange` not yet implemented")
-}
-
 // MockInterface_GetTokenByROPC_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTokenByROPC'
 type MockInterface_GetTokenByROPC_Call struct {
 	*mock.Call
@@ -515,6 +503,74 @@ func (_c *MockInterface_GetTokenByROPC_Call) Return(tokenSet *oidc.TokenSet, err
 }
 
 func (_c *MockInterface_GetTokenByROPC_Call) RunAndReturn(run func(ctx context.Context, username string, password string) (*oidc.TokenSet, error)) *MockInterface_GetTokenByROPC_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetTokenByTokenExchange provides a mock function for the type MockInterface
+func (_mock *MockInterface) GetTokenByTokenExchange(ctx context.Context, in client.GetTokenByTokenExchangeInput) (*oidc.TokenSet, error) {
+	ret := _mock.Called(ctx, in)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTokenByTokenExchange")
+	}
+
+	var r0 *oidc.TokenSet
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, client.GetTokenByTokenExchangeInput) (*oidc.TokenSet, error)); ok {
+		return returnFunc(ctx, in)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, client.GetTokenByTokenExchangeInput) *oidc.TokenSet); ok {
+		r0 = returnFunc(ctx, in)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*oidc.TokenSet)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, client.GetTokenByTokenExchangeInput) error); ok {
+		r1 = returnFunc(ctx, in)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockInterface_GetTokenByTokenExchange_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTokenByTokenExchange'
+type MockInterface_GetTokenByTokenExchange_Call struct {
+	*mock.Call
+}
+
+// GetTokenByTokenExchange is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in client.GetTokenByTokenExchangeInput
+func (_e *MockInterface_Expecter) GetTokenByTokenExchange(ctx any, in any) *MockInterface_GetTokenByTokenExchange_Call {
+	return &MockInterface_GetTokenByTokenExchange_Call{Call: _e.mock.On("GetTokenByTokenExchange", ctx, in)}
+}
+
+func (_c *MockInterface_GetTokenByTokenExchange_Call) Run(run func(ctx context.Context, in client.GetTokenByTokenExchangeInput)) *MockInterface_GetTokenByTokenExchange_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 client.GetTokenByTokenExchangeInput
+		if args[1] != nil {
+			arg1 = args[1].(client.GetTokenByTokenExchangeInput)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockInterface_GetTokenByTokenExchange_Call) Return(tokenSet *oidc.TokenSet, err error) *MockInterface_GetTokenByTokenExchange_Call {
+	_c.Call.Return(tokenSet, err)
+	return _c
+}
+
+func (_c *MockInterface_GetTokenByTokenExchange_Call) RunAndReturn(run func(ctx context.Context, in client.GetTokenByTokenExchangeInput) (*oidc.TokenSet, error)) *MockInterface_GetTokenByTokenExchange_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/cmd/authentication.go
+++ b/pkg/cmd/authentication.go
@@ -75,7 +75,7 @@ func (o *authenticationOptions) expandHomedir() {
 
 func (o *authenticationOptions) grantOptionSet() (s authentication.GrantOptionSet, err error) {
 	switch {
-	case o.GrantType == "authcode" || (o.GrantType == "auto" && o.Username == ""):
+	case o.GrantType == "authcode" || (o.GrantType == "auto" && o.Username == "" && o.TokenExchangeSubjectToken == ""):
 		s.AuthCodeBrowserOption = &authcode.BrowserOption{
 			BindAddress:                o.ListenAddress,
 			SkipOpenBrowser:            o.SkipOpenBrowser,
@@ -106,10 +106,18 @@ func (o *authenticationOptions) grantOptionSet() (s authentication.GrantOptionSe
 			endpointparams[k] = []string{v}
 		}
 		s.ClientCredentialsOption = &client.GetTokenByClientCredentialsInput{EndpointParams: endpointparams}
-	case o.GrantType == "token-exchange":
-		// TODO(vdbe): implement this
-		s.TokenExchangeOption = &tokenexchange.TokenExchangeOption{}
-		err = fmt.Errorf("grant-type %s is not implemented", allGrantType)
+	case o.GrantType == "token-exchange" || (o.GrantType == "auto" && o.TokenExchangeSubjectToken != ""):
+		s.TokenExchangeOption = &tokenexchange.TokenExchangeOption{
+			Resource:           o.TokenExchangeResource,
+			Audience:           o.TokenExchangeAudience,
+			RequestedTokenType: o.TokenExchangeRequestedTokenType,
+			SubjectToken:       o.TokenExchangeSubjectToken,
+			SubjectTokenType:   o.TokenExchangeSubjectTokenType,
+			ActorToken:         o.TokenExchangeActorToken,
+			ActorTokenType:     o.TokenExchangeActorTokenType,
+
+			AuthRequestExtraParams: o.AuthRequestExtraParams,
+		}
 	default:
 		err = fmt.Errorf("grant-type must be one of (%s)", allGrantType)
 	}

--- a/pkg/cmd/authentication.go
+++ b/pkg/cmd/authentication.go
@@ -26,6 +26,14 @@ type authenticationOptions struct {
 	AuthRequestExtraParams     map[string]string
 	Username                   string
 	Password                   string
+
+	TokenExchangeResource           []string
+	TokenExchangeAudience           []string
+	TokenExchangeRequestedTokenType string
+	TokenExchangeSubjectToken       string
+	TokenExchangeSubjectTokenType   string
+	TokenExchangeActorToken         string
+	TokenExchangeActorTokenType     string
 }
 
 var allGrantType = strings.Join([]string{
@@ -35,6 +43,7 @@ var allGrantType = strings.Join([]string{
 	"password",
 	"device-code",
 	"client-credentials",
+	"token-exchange",
 }, "|")
 
 func (o *authenticationOptions) addFlags(f *pflag.FlagSet) {
@@ -46,9 +55,16 @@ func (o *authenticationOptions) addFlags(f *pflag.FlagSet) {
 	f.StringVar(&o.LocalServerCertFile, "local-server-cert", "", "[authcode] Certificate path for the local server")
 	f.StringVar(&o.LocalServerKeyFile, "local-server-key", "", "[authcode] Certificate key path for the local server")
 	f.StringVar(&o.OpenURLAfterAuthentication, "open-url-after-authentication", "", "[authcode] If set, open the URL in the browser after authentication")
-	f.StringToStringVar(&o.AuthRequestExtraParams, "oidc-auth-request-extra-params", nil, "[authcode, authcode-keyboard, client-credentials] Extra query parameters to send with an authentication request")
+	f.StringToStringVar(&o.AuthRequestExtraParams, "oidc-auth-request-extra-params", nil, "[authcode, authcode-keyboard, client-credentials, token-exchange] Extra query parameters to send with an authentication request")
 	f.StringVar(&o.Username, "username", "", "[password] Username for resource owner password credentials grant")
 	f.StringVar(&o.Password, "password", "", "[password] Password for resource owner password credentials grant")
+	f.StringSliceVar(&o.TokenExchangeResource, "token-exchange-resource", []string{}, "[token-exchange] a URI for the target resource the client intends to use")
+	f.StringSliceVar(&o.TokenExchangeAudience, "token-exchange-audience", []string{}, "[token-exchange] the audience the client intends to use")
+	f.StringVar(&o.TokenExchangeRequestedTokenType, "token-exchange-requested-token-type", "", "[token-exchange] return type desired in response, e.g. id-token or access-token")
+	f.StringVar(&o.TokenExchangeSubjectToken, "token-exchange-subject-token", "", "[token-exchange] the token to exchange (required)")
+	f.StringVar(&o.TokenExchangeSubjectTokenType, "token-exchange-subject-token-type", "", "[token-exchange] the type of token provided, e.g. id-token or access-token (required)")
+	f.StringVar(&o.TokenExchangeActorToken, "token-exchange-actor-token", "", "[token-exchange] optional token for delegated access pattern")
+	f.StringVar(&o.TokenExchangeActorTokenType, "token-exchange-actor-token-type", "", "[token-exchange] type of the actor token, e.g. id-token or access-token")
 }
 
 func (o *authenticationOptions) expandHomedir() {
@@ -89,6 +105,9 @@ func (o *authenticationOptions) grantOptionSet() (s authentication.GrantOptionSe
 			endpointparams[k] = []string{v}
 		}
 		s.ClientCredentialsOption = &client.GetTokenByClientCredentialsInput{EndpointParams: endpointparams}
+	case o.GrantType == "token-exchange":
+		// TODO(vdbe): implement this
+		err = fmt.Errorf("grant-type %s is not implemented", allGrantType)
 	default:
 		err = fmt.Errorf("grant-type must be one of (%s)", allGrantType)
 	}

--- a/pkg/cmd/authentication.go
+++ b/pkg/cmd/authentication.go
@@ -12,6 +12,7 @@ import (
 	"github.com/int128/kubelogin/pkg/usecases/authentication/authcode"
 	"github.com/int128/kubelogin/pkg/usecases/authentication/devicecode"
 	"github.com/int128/kubelogin/pkg/usecases/authentication/ropc"
+	"github.com/int128/kubelogin/pkg/usecases/authentication/tokenexchange"
 )
 
 type authenticationOptions struct {
@@ -62,7 +63,7 @@ func (o *authenticationOptions) addFlags(f *pflag.FlagSet) {
 	f.StringSliceVar(&o.TokenExchangeAudience, "token-exchange-audience", []string{}, "[token-exchange] the audience the client intends to use")
 	f.StringVar(&o.TokenExchangeRequestedTokenType, "token-exchange-requested-token-type", "", "[token-exchange] return type desired in response, e.g. id-token or access-token")
 	f.StringVar(&o.TokenExchangeSubjectToken, "token-exchange-subject-token", "", "[token-exchange] the token to exchange (required)")
-	f.StringVar(&o.TokenExchangeSubjectTokenType, "token-exchange-subject-token-type", "", "[token-exchange] the type of token provided, e.g. id-token or access-token (required)")
+	f.StringVar(&o.TokenExchangeSubjectTokenType, "token-exchange-subject-token-type", client.AccessTokenType, "[token-exchange] the type of token provided, e.g. id-token or access-token (required)")
 	f.StringVar(&o.TokenExchangeActorToken, "token-exchange-actor-token", "", "[token-exchange] optional token for delegated access pattern")
 	f.StringVar(&o.TokenExchangeActorTokenType, "token-exchange-actor-token-type", "", "[token-exchange] type of the actor token, e.g. id-token or access-token")
 }
@@ -107,6 +108,7 @@ func (o *authenticationOptions) grantOptionSet() (s authentication.GrantOptionSe
 		s.ClientCredentialsOption = &client.GetTokenByClientCredentialsInput{EndpointParams: endpointparams}
 	case o.GrantType == "token-exchange":
 		// TODO(vdbe): implement this
+		s.TokenExchangeOption = &tokenexchange.TokenExchangeOption{}
 		err = fmt.Errorf("grant-type %s is not implemented", allGrantType)
 	default:
 		err = fmt.Errorf("grant-type must be one of (%s)", allGrantType)

--- a/pkg/di/wire_gen.go
+++ b/pkg/di/wire_gen.go
@@ -25,6 +25,7 @@ import (
 	"github.com/int128/kubelogin/pkg/usecases/authentication/clientcredentials"
 	"github.com/int128/kubelogin/pkg/usecases/authentication/devicecode"
 	"github.com/int128/kubelogin/pkg/usecases/authentication/ropc"
+	"github.com/int128/kubelogin/pkg/usecases/authentication/tokenexchange"
 	"github.com/int128/kubelogin/pkg/usecases/clean"
 	"github.com/int128/kubelogin/pkg/usecases/credentialplugin"
 	"github.com/int128/kubelogin/pkg/usecases/setup"
@@ -80,6 +81,9 @@ func NewCmdForHeadless(clockInterface clock.Interface, stdin stdio.Stdin, stdout
 	clientCredentials := &clientcredentials.ClientCredentials{
 		Logger: loggerInterface,
 	}
+	tokenExchange := &tokenexchange.TokenExchange{
+		Logger: loggerInterface,
+	}
 	authenticationAuthentication := &authentication.Authentication{
 		ClientFactory:     factory,
 		Logger:            loggerInterface,
@@ -88,6 +92,7 @@ func NewCmdForHeadless(clockInterface clock.Interface, stdin stdio.Stdin, stdout
 		ROPC:              ropcROPC,
 		DeviceCode:        deviceCode,
 		ClientCredentials: clientCredentials,
+		TokenExchange:     tokenExchange,
 	}
 	loader3 := &loader2.Loader{}
 	writerWriter := &writer.Writer{}

--- a/pkg/oidc/client/client.go
+++ b/pkg/oidc/client/client.go
@@ -22,6 +22,7 @@ type Interface interface {
 	NegotiatedPKCEMethod() pkce.Method
 	GetTokenByROPC(ctx context.Context, username, password string) (*oidc.TokenSet, error)
 	GetTokenByClientCredentials(ctx context.Context, in GetTokenByClientCredentialsInput) (*oidc.TokenSet, error)
+	GetTokenByTokenExchange(ctx context.Context, in GetTokenByTokenExchangeInput) (*oidc.TokenSet, error)
 	GetDeviceAuthorization(ctx context.Context) (*oauth2dev.AuthorizationResponse, error)
 	ExchangeDeviceCode(ctx context.Context, authResponse *oauth2dev.AuthorizationResponse) (*oidc.TokenSet, error)
 	Refresh(ctx context.Context, refreshToken string) (*oidc.TokenSet, error)

--- a/pkg/oidc/client/tokenexchange.go
+++ b/pkg/oidc/client/tokenexchange.go
@@ -3,20 +3,75 @@ package client
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/int128/kubelogin/pkg/oidc"
 	"golang.org/x/oauth2"
 )
 
+const TokenExchangeGrantType = "urn:ietf:params:oauth:grant-type:token-exchange"
+const AccessTokenType = "urn:ietf:params:oauth:token-type:access_token"
+
 type GetTokenByTokenExchangeInput struct {
+	Resource           []string
+	Audience           []string
+	RequestedTokenType string
+	SubjectToken       string
+	SubjectTokenType   string
+	ActorToken         string
+	ActorTokenType     string
+
+	AuthRequestExtraParams map[string]string
 }
 
 func (c *client) GetTokenByTokenExchange(ctx context.Context, in GetTokenByTokenExchangeInput) (*oidc.TokenSet, error) {
 	ctx = c.wrapContext(ctx)
-	c.logger.V(1).Infof("")
+	c.logger.V(1).Infof(
+		"Token Exchange Request: ClientID=%s, AuthURL=%s, Scopes=%v, Audience=%v, Resource=%v",
+		c.oauth2Config.ClientID,
+		c.oauth2Config.Endpoint.AuthURL,
+		c.oauth2Config.Scopes,
+		in.Audience,
+		in.Resource,
+	)
 
-	// TODO(vdbe): implement this
-	token, err := &oauth2.Token{}, fmt.Errorf("`GetTokenByTokenExchange` not yet implemented")
+	addParamIfNotEmpty := func(opts []oauth2.AuthCodeOption, key, value string) []oauth2.AuthCodeOption {
+		if value != "" {
+			return append(opts, oauth2.SetAuthURLParam(key, value))
+		}
+		return opts
+	}
+
+	opts := []oauth2.AuthCodeOption{
+		oauth2.SetAuthURLParam("grant_type", TokenExchangeGrantType),
+		oauth2.SetAuthURLParam("subject_token", in.SubjectToken),
+		oauth2.SetAuthURLParam("subject_token_type", in.SubjectTokenType),
+	}
+
+	for _, res := range in.Resource {
+		if res != "" {
+			opts = append(opts, oauth2.SetAuthURLParam("resource", res))
+		}
+	}
+
+	for _, aud := range in.Audience {
+		if aud != "" {
+			opts = append(opts, oauth2.SetAuthURLParam("audience", aud))
+		}
+	}
+	opts = addParamIfNotEmpty(opts, "requested_token_type", in.RequestedTokenType)
+	opts = addParamIfNotEmpty(opts, "actor_token", in.ActorToken)
+	opts = addParamIfNotEmpty(opts, "actor_token_type", in.ActorTokenType)
+
+	if len(c.oauth2Config.Scopes) > 0 {
+		opts = append(opts, oauth2.SetAuthURLParam("scope", strings.Join(c.oauth2Config.Scopes, " ")))
+	}
+
+	for param, val := range in.AuthRequestExtraParams {
+		opts = append(opts, oauth2.SetAuthURLParam(param, val))
+	}
+
+	token, err := c.oauth2Config.Exchange(ctx, "", opts...)
 	if err != nil {
 		return nil, fmt.Errorf("could not acquire token: %w", err)
 	}

--- a/pkg/oidc/client/tokenexchange.go
+++ b/pkg/oidc/client/tokenexchange.go
@@ -1,0 +1,25 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/int128/kubelogin/pkg/oidc"
+	"golang.org/x/oauth2"
+)
+
+type GetTokenByTokenExchangeInput struct {
+}
+
+func (c *client) GetTokenByTokenExchange(ctx context.Context, in GetTokenByTokenExchangeInput) (*oidc.TokenSet, error) {
+	ctx = c.wrapContext(ctx)
+	c.logger.V(1).Infof("")
+
+	// TODO(vdbe): implement this
+	token, err := &oauth2.Token{}, fmt.Errorf("`GetTokenByTokenExchange` not yet implemented")
+	if err != nil {
+		return nil, fmt.Errorf("could not acquire token: %w", err)
+	}
+
+	return c.verifyToken(ctx, token, "")
+}

--- a/pkg/usecases/authentication/authentication.go
+++ b/pkg/usecases/authentication/authentication.go
@@ -25,6 +25,7 @@ var Set = wire.NewSet(
 	wire.Struct(new(ropc.ROPC), "*"),
 	wire.Struct(new(devicecode.DeviceCode), "*"),
 	wire.Struct(new(clientcredentials.ClientCredentials), "*"),
+	wire.Struct(new(tokenexchange.TokenExchange), "*"),
 )
 
 type Interface interface {
@@ -75,7 +76,6 @@ type Output struct {
 	TokenSet oidc.TokenSet
 }
 
-// TODO(vdbe): update comment to include `TokenExchange`
 // Authentication provides the internal use-case of authentication.
 //
 // If the IDToken is not set, it performs the authentication flow.
@@ -85,8 +85,9 @@ type Output struct {
 //
 // The authentication flow is determined as:
 //
-// If the Username is not set, it performs the authorization code flow.
-// Otherwise, it performs the resource owner password credentials flow.
+// If the Username is set, it performs the resource owner password credentials flow.
+// If SubjectToken is set, it performs the token exchange flow.
+// Otherwise, it performs the authorization code flow.
 // If the Password is not set, it asks a password by the prompt.
 type Authentication struct {
 	ClientFactory     client.FactoryInterface
@@ -153,7 +154,7 @@ func (u *Authentication) Do(ctx context.Context, in Input) (*Output, error) {
 	if in.GrantOptionSet.TokenExchangeOption != nil {
 		tokenSet, err := u.TokenExchange.Do(ctx, in.GrantOptionSet.TokenExchangeOption, oidcClient)
 		if err != nil {
-			return nil, fmt.Errorf("token-exchange: %w", err)
+			return nil, fmt.Errorf("token-exchange error: %w", err)
 		}
 		return &Output{TokenSet: *tokenSet}, nil
 	}

--- a/pkg/usecases/authentication/authentication.go
+++ b/pkg/usecases/authentication/authentication.go
@@ -13,6 +13,7 @@ import (
 	"github.com/int128/kubelogin/pkg/usecases/authentication/clientcredentials"
 	"github.com/int128/kubelogin/pkg/usecases/authentication/devicecode"
 	"github.com/int128/kubelogin/pkg/usecases/authentication/ropc"
+	"github.com/int128/kubelogin/pkg/usecases/authentication/tokenexchange"
 )
 
 // Set provides the use-case of Authentication.
@@ -44,6 +45,7 @@ type GrantOptionSet struct {
 	ROPCOption              *ropc.Option
 	DeviceCodeOption        *devicecode.Option
 	ClientCredentialsOption *client.GetTokenByClientCredentialsInput
+	TokenExchangeOption     *tokenexchange.TokenExchangeOption
 }
 
 // AuthRequestExtraParams returns the extra parameters for the auth request
@@ -73,6 +75,7 @@ type Output struct {
 	TokenSet oidc.TokenSet
 }
 
+// TODO(vdbe): update comment to include `TokenExchange`
 // Authentication provides the internal use-case of authentication.
 //
 // If the IDToken is not set, it performs the authentication flow.
@@ -93,6 +96,7 @@ type Authentication struct {
 	ROPC              *ropc.ROPC
 	DeviceCode        *devicecode.DeviceCode
 	ClientCredentials *clientcredentials.ClientCredentials
+	TokenExchange     *tokenexchange.TokenExchange
 }
 
 func (u *Authentication) Do(ctx context.Context, in Input) (*Output, error) {
@@ -143,6 +147,13 @@ func (u *Authentication) Do(ctx context.Context, in Input) (*Output, error) {
 		tokenSet, err := u.ClientCredentials.Do(ctx, in.GrantOptionSet.ClientCredentialsOption, oidcClient)
 		if err != nil {
 			return nil, fmt.Errorf("client-credentials error: %w", err)
+		}
+		return &Output{TokenSet: *tokenSet}, nil
+	}
+	if in.GrantOptionSet.TokenExchangeOption != nil {
+		tokenSet, err := u.TokenExchange.Do(ctx, in.GrantOptionSet.TokenExchangeOption, oidcClient)
+		if err != nil {
+			return nil, fmt.Errorf("token-exchange: %w", err)
 		}
 		return &Output{TokenSet: *tokenSet}, nil
 	}

--- a/pkg/usecases/authentication/authentication_test.go
+++ b/pkg/usecases/authentication/authentication_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/int128/kubelogin/pkg/usecases/authentication/authcode"
 	"github.com/int128/kubelogin/pkg/usecases/authentication/clientcredentials"
 	"github.com/int128/kubelogin/pkg/usecases/authentication/ropc"
+	"github.com/int128/kubelogin/pkg/usecases/authentication/tokenexchange"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -207,6 +208,50 @@ func TestAuthentication_Do(t *testing.T) {
 			ClientFactory: mockClientFactory,
 			Logger:        testingLogger.New(t),
 			ClientCredentials: &clientcredentials.ClientCredentials{
+				Logger: testingLogger.New(t),
+			},
+		}
+		got, err := u.Do(ctx, in)
+		if err != nil {
+			t.Errorf("Do returned error: %+v", err)
+		}
+		want := &Output{
+			TokenSet: oidc.TokenSet{
+				IDToken: "TEST_ID_TOKEN",
+			},
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("NoToken/TokenExchange", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+		defer cancel()
+		teIn := tokenexchange.TokenExchangeOption{
+			SubjectToken:     "SUBJECT_TOKEN",
+			SubjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+		}
+		in := Input{
+			Provider:        dummyProvider,
+			TLSClientConfig: dummyTLSClientConfig,
+			GrantOptionSet:  GrantOptionSet{TokenExchangeOption: &teIn},
+		}
+		mockClient := client_mock.NewMockInterface(t)
+		mockClient.EXPECT().
+			GetTokenByTokenExchange(ctx, client.GetTokenByTokenExchangeInput{
+				SubjectToken:     "SUBJECT_TOKEN",
+				SubjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+			}).
+			Return(&oidc.TokenSet{IDToken: "TEST_ID_TOKEN"}, nil).Once()
+		mockClientFactory := client_mock.NewMockFactoryInterface(t)
+		mockClientFactory.EXPECT().
+			New(ctx, dummyProvider, dummyTLSClientConfig).
+			Return(mockClient, nil)
+		u := Authentication{
+			ClientFactory: mockClientFactory,
+			Logger:        testingLogger.New(t),
+			TokenExchange: &tokenexchange.TokenExchange{
 				Logger: testingLogger.New(t),
 			},
 		}

--- a/pkg/usecases/authentication/tokenexchange/tokenexchange.go
+++ b/pkg/usecases/authentication/tokenexchange/tokenexchange.go
@@ -1,0 +1,34 @@
+package tokenexchange
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/int128/kubelogin/pkg/infrastructure/logger"
+	"github.com/int128/kubelogin/pkg/oidc"
+	"github.com/int128/kubelogin/pkg/oidc/client"
+)
+
+type TokenExchangeOption struct {
+}
+
+// TokenExchage provides the oauth2 token exchange flow.
+type TokenExchange struct {
+	Logger logger.Interface
+}
+
+func (u *TokenExchange) Do(ctx context.Context, in *TokenExchangeOption, oidcClient client.Interface) (*oidc.TokenSet, error) {
+	u.Logger.V(1).Infof("starting the oauth2 toke exchange code flow")
+	if in == nil {
+		return nil, fmt.Errorf("nil input")
+	}
+
+	// TODO(vdbe): implement this
+	tokenSet, err := &oidc.TokenSet{}, fmt.Errorf("tokenexchange tokenset not yet implemented")
+	if err != nil {
+		return nil, fmt.Errorf("could not exchange the token: %w", err)
+	}
+
+	u.Logger.V(1).Infof("finished the oauth2 toke exchange code flow")
+	return tokenSet, nil
+}

--- a/pkg/usecases/authentication/tokenexchange/tokenexchange.go
+++ b/pkg/usecases/authentication/tokenexchange/tokenexchange.go
@@ -10,6 +10,15 @@ import (
 )
 
 type TokenExchangeOption struct {
+	Resource           []string
+	Audience           []string
+	RequestedTokenType string
+	SubjectToken       string
+	SubjectTokenType   string
+	ActorToken         string
+	ActorTokenType     string
+
+	AuthRequestExtraParams map[string]string
 }
 
 // TokenExchage provides the oauth2 token exchange flow.
@@ -18,17 +27,41 @@ type TokenExchange struct {
 }
 
 func (u *TokenExchange) Do(ctx context.Context, in *TokenExchangeOption, oidcClient client.Interface) (*oidc.TokenSet, error) {
-	u.Logger.V(1).Infof("starting the oauth2 toke exchange code flow")
+	u.Logger.V(1).Infof("starting the oauth2 toke exchange flow")
 	if in == nil {
 		return nil, fmt.Errorf("nil input")
 	}
 
-	// TODO(vdbe): implement this
-	tokenSet, err := &oidc.TokenSet{}, fmt.Errorf("tokenexchange tokenset not yet implemented")
+	if in.SubjectToken == "" {
+		return nil, fmt.Errorf("subject_token is required")
+	}
+
+	if in.SubjectTokenType == "" {
+		return nil, fmt.Errorf("subject_token_type is required")
+	}
+
+	if in.ActorToken != "" && in.ActorTokenType == "" {
+		return nil, fmt.Errorf("actor_token_type is required when actor_token is set")
+	}
+	if in.ActorToken == "" && in.ActorTokenType != "" {
+		return nil, fmt.Errorf("actor_token_type may not be set when actor_token is not set")
+	}
+
+	tokenSet, err := oidcClient.GetTokenByTokenExchange(ctx, client.GetTokenByTokenExchangeInput{
+		Resource:           in.Resource,
+		Audience:           in.Audience,
+		RequestedTokenType: in.RequestedTokenType,
+		SubjectToken:       in.SubjectToken,
+		SubjectTokenType:   in.SubjectTokenType,
+		ActorToken:         in.ActorToken,
+		ActorTokenType:     in.ActorTokenType,
+
+		AuthRequestExtraParams: in.AuthRequestExtraParams,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("could not exchange the token: %w", err)
 	}
 
-	u.Logger.V(1).Infof("finished the oauth2 toke exchange code flow")
+	u.Logger.V(1).Infof("finished the oauth2 token exchange flow")
 	return tokenSet, nil
 }

--- a/pkg/usecases/authentication/tokenexchange/tokenexchange_test.go
+++ b/pkg/usecases/authentication/tokenexchange/tokenexchange_test.go
@@ -1,0 +1,209 @@
+package tokenexchange
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/int128/kubelogin/mocks/github.com/int128/kubelogin/pkg/oidc/client_mock"
+	"github.com/int128/kubelogin/pkg/oidc"
+	"github.com/int128/kubelogin/pkg/oidc/client"
+	"github.com/int128/kubelogin/pkg/testing/logger"
+)
+
+func TestTokenExchange_Do(t *testing.T) {
+	t.Run("MissingSubjectToken", func(t *testing.T) {
+		ctx := context.TODO()
+		u := TokenExchange{
+			Logger: logger.New(t),
+		}
+		in := &TokenExchangeOption{
+			SubjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+		}
+		_, err := u.Do(ctx, in, client_mock.NewMockInterface(t))
+		if err == nil {
+			t.Errorf("err wants non-nil but nil")
+		}
+	})
+
+	t.Run("MissingSubjectTokenType", func(t *testing.T) {
+		ctx := context.TODO()
+		u := TokenExchange{
+			Logger: logger.New(t),
+		}
+		in := &TokenExchangeOption{
+			SubjectToken: "SUBJECT_TOKEN",
+		}
+		out, err := u.Do(ctx, in, client_mock.NewMockInterface(t))
+		if err == nil {
+			t.Errorf("err wants non-nil but nil")
+		}
+		if out != nil {
+			t.Errorf("out wants nil but %+v", out)
+		}
+	})
+
+	t.Run("ActorTokenWithoutActorTokenType", func(t *testing.T) {
+		ctx := context.TODO()
+		u := TokenExchange{
+			Logger: logger.New(t),
+		}
+		in := &TokenExchangeOption{
+			SubjectToken:     "SUBJECT_TOKEN",
+			SubjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+			ActorToken:       "ACTOR_TOKEN",
+		}
+		out, err := u.Do(ctx, in, client_mock.NewMockInterface(t))
+		if err == nil {
+			t.Errorf("err wants non-nil but nil")
+		}
+		if out != nil {
+			t.Errorf("out wants nil but %+v", out)
+		}
+	})
+
+	t.Run("ActorTokenTypeWithoutActorToken", func(t *testing.T) {
+		ctx := context.TODO()
+		u := TokenExchange{
+			Logger: logger.New(t),
+		}
+		in := &TokenExchangeOption{
+			SubjectToken:     "SUBJECT_TOKEN",
+			SubjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+			ActorTokenType:   "urn:ietf:params:oauth:token-type:access_token",
+		}
+		out, err := u.Do(ctx, in, client_mock.NewMockInterface(t))
+		if err == nil {
+			t.Errorf("err wants non-nil but nil")
+		}
+		if out != nil {
+			t.Errorf("out wants nil but %+v", out)
+		}
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		ctx := context.TODO()
+		mockClient := client_mock.NewMockInterface(t)
+		u := TokenExchange{
+			Logger: logger.New(t),
+		}
+		in := &TokenExchangeOption{
+			SubjectToken:     "SUBJECT_TOKEN",
+			SubjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+		}
+		wantInput := client.GetTokenByTokenExchangeInput{
+			SubjectToken:     "SUBJECT_TOKEN",
+			SubjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+		}
+		testToken := &oidc.TokenSet{
+			IDToken:      "YOUR_ID_TOKEN",
+			RefreshToken: "YOUR_REFRESH_TOKEN",
+		}
+		mockClient.EXPECT().GetTokenByTokenExchange(ctx, wantInput).Return(testToken, nil).Once()
+		got, err := u.Do(ctx, in, mockClient)
+		if err != nil {
+			t.Errorf("Do returned unexpected error: %v", err)
+		}
+		if diff := cmp.Diff(testToken, got); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("SuccessWithActorToken", func(t *testing.T) {
+		ctx := context.TODO()
+		mockClient := client_mock.NewMockInterface(t)
+		u := TokenExchange{
+			Logger: logger.New(t),
+		}
+		in := &TokenExchangeOption{
+			SubjectToken:     "SUBJECT_TOKEN",
+			SubjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+			ActorToken:       "ACTOR_TOKEN",
+			ActorTokenType:   "urn:ietf:params:oauth:token-type:access_token",
+		}
+		wantInput := client.GetTokenByTokenExchangeInput{
+			SubjectToken:     "SUBJECT_TOKEN",
+			SubjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+			ActorToken:       "ACTOR_TOKEN",
+			ActorTokenType:   "urn:ietf:params:oauth:token-type:access_token",
+		}
+		testToken := &oidc.TokenSet{
+			IDToken:      "YOUR_ID_TOKEN",
+			RefreshToken: "YOUR_REFRESH_TOKEN",
+		}
+		mockClient.EXPECT().GetTokenByTokenExchange(ctx, wantInput).Return(testToken, nil).Once()
+		got, err := u.Do(ctx, in, mockClient)
+		if err != nil {
+			t.Errorf("Do returned unexpected error: %v", err)
+		}
+		if diff := cmp.Diff(testToken, got); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("SuccessWithExtraParams", func(t *testing.T) {
+		ctx := context.TODO()
+		mockClient := client_mock.NewMockInterface(t)
+		u := TokenExchange{
+			Logger: logger.New(t),
+		}
+		in := &TokenExchangeOption{
+			Resource:           []string{"https://resource.example.com"},
+			Audience:           []string{"https://audience.example.com"},
+			RequestedTokenType: "urn:ietf:params:oauth:token-type:refresh_token",
+			SubjectToken:       "SUBJECT_TOKEN",
+			SubjectTokenType:   "urn:ietf:params:oauth:token-type:access_token",
+			AuthRequestExtraParams: map[string]string{
+				"audience": "api1",
+			},
+		}
+		wantInput := client.GetTokenByTokenExchangeInput{
+			Resource:           []string{"https://resource.example.com"},
+			Audience:           []string{"https://audience.example.com"},
+			RequestedTokenType: "urn:ietf:params:oauth:token-type:refresh_token",
+			SubjectToken:       "SUBJECT_TOKEN",
+			SubjectTokenType:   "urn:ietf:params:oauth:token-type:access_token",
+			AuthRequestExtraParams: map[string]string{
+				"audience": "api1",
+			},
+		}
+		testToken := &oidc.TokenSet{
+			IDToken:      "YOUR_ID_TOKEN",
+			RefreshToken: "YOUR_REFRESH_TOKEN",
+		}
+		mockClient.EXPECT().GetTokenByTokenExchange(ctx, wantInput).Return(testToken, nil).Once()
+		got, err := u.Do(ctx, in, mockClient)
+		if err != nil {
+			t.Errorf("Do returned error: %+v", err)
+		}
+		if diff := cmp.Diff(testToken, got); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("ClientError", func(t *testing.T) {
+		ctx := context.TODO()
+		mockClient := client_mock.NewMockInterface(t)
+		u := TokenExchange{
+			Logger: logger.New(t),
+		}
+		in := &TokenExchangeOption{
+			SubjectToken:     "SUBJECT_TOKEN",
+			SubjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+		}
+		wantInput := client.GetTokenByTokenExchangeInput{
+			SubjectToken:     "SUBJECT_TOKEN",
+			SubjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+		}
+		errTest := errors.New("could not exchange")
+		mockClient.EXPECT().GetTokenByTokenExchange(ctx, wantInput).Return(nil, errTest).Once()
+		out, err := u.Do(ctx, in, mockClient)
+		if !errors.Is(err, errTest) {
+			t.Errorf("returned error is not the test error: %v", err)
+		}
+		if out != nil {
+			t.Errorf("out wants nil but %+v", out)
+		}
+	})
+}


### PR DESCRIPTION
Implentation of [token exchange](https://datatracker.ietf.org/doc/html/rfc8693), loosely based on #1052.

I have personally only tested it with [kanidm](https://github.com/kanidm/kanidm) [service accounts](https://kanidm.github.io/kanidm/stable/accounts/service_accounts.html) and k3s.