### PR TITLE
fix(release): stamp tag name into main.version instead of commit SHA

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,7 +79,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
-      - run: go build -ldflags "-X main.version=$GITHUB_SHA"
+      - run: go build -ldflags "-X main.version=${{ github.ref_name }}"
       - uses: int128/go-release-action@9e1d6ec29fc6ffc2ba55f631baf4a73017d228e1 # v2.5.0
         with:
           binary: kubelogin


### PR DESCRIPTION
## Summary

`kubelogin --version` prints the raw commit SHA instead of the release tag on tagged releases (e.g. `v1.36.1`, `v1.36.2`), because the release workflow stamps `$GITHUB_SHA` into `main.version` unconditionally:

```yaml
- run: go build -ldflags "-X main.version=$GITHUB_SHA"
```

`$GITHUB_SHA` is always the commit hash, regardless of whether the build was triggered by a tag push or a branch push. `main.version` (declared in `main.go`) is meant to carry the release tag and is surfaced via Cobra's `--version` flag and the `version` subcommand.

This is a regression from 330947e ("Support immutable releases", #1552), which replaced `github.ref_name` with `$GITHUB_SHA` so the same job could also build on branch pushes. That change had the side effect of breaking the tag-push case, since a single variable was being used to carry two different pieces of information (the release tag and the triggering ref).

## Fix

Restore `github.ref_name`, which resolves to the tag name on a tag push (e.g. `v1.36.2`) and to the branch name on a branch/PR build (e.g. `master`) — a reasonable placeholder, consistent with the existing `"HEAD"` default already in `main.go`.

```diff
-      - run: go build -ldflags "-X main.version=$GITHUB_SHA"
+      - run: go build -ldflags "-X main.version=${{ github.ref_name }}"
```

This is a one-line change scoped to the release workflow; no Go code changes are needed.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes (all packages green)
- [x] Verified via `git log`/`git show` that 330947e is indeed the commit that swapped `github.ref_name` for `$GITHUB_SHA`
- [x] Next tagged release should show the tag in `kubelogin --version` output instead of a commit SHA

Fixes #1590