### PR TITLE
Add `--oidc-auth-request-access-type` flag to get-token

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,6 +32,7 @@ Flags:
       --local-server-key string                         [authcode] Certificate key path for the local server
       --open-url-after-authentication string            [authcode] If set, open the URL in the browser after authentication
       --oidc-auth-request-extra-params stringToString   [authcode, authcode-keyboard, client-credentials] Extra query parameters to send with an authentication request (default [])
+      --oidc-auth-request-access-type string            [authcode, authcode-keyboard] Access type to request. One of (offline|online). Set to online to request no refresh token (default "offline")
       --username string                                 [password] Username for resource owner password credentials grant
       --password string                                 [password] Password for resource owner password credentials grant
   -h, --help                                            help for get-token
@@ -133,6 +134,17 @@ Deleted the token cache from the keyring
 ```
 
 For systems with immutable storage and no keyring, a cache type of none is available.
+
+### Refresh token
+
+By default kubelogin sends `access_type=offline` in the authentication request so that the provider returns a refresh token.
+If you do not want a refresh token to be issued (for example your security policy does not allow long-lived tokens on the machine), set the access type to online.
+
+```yaml
+- --oidc-auth-request-access-type=online
+```
+
+Kubelogin will re-run the authentication when the ID token has expired, since there is no refresh token to use.
 
 ### Home directory expansion
 

--- a/pkg/cmd/authentication.go
+++ b/pkg/cmd/authentication.go
@@ -24,9 +24,15 @@ type authenticationOptions struct {
 	LocalServerKeyFile         string
 	OpenURLAfterAuthentication string
 	AuthRequestExtraParams     map[string]string
+	AuthRequestAccessType      string
 	Username                   string
 	Password                   string
 }
+
+var allAccessType = strings.Join([]string{
+	"offline",
+	"online",
+}, "|")
 
 var allGrantType = strings.Join([]string{
 	"auto",
@@ -47,6 +53,7 @@ func (o *authenticationOptions) addFlags(f *pflag.FlagSet) {
 	f.StringVar(&o.LocalServerKeyFile, "local-server-key", "", "[authcode] Certificate key path for the local server")
 	f.StringVar(&o.OpenURLAfterAuthentication, "open-url-after-authentication", "", "[authcode] If set, open the URL in the browser after authentication")
 	f.StringToStringVar(&o.AuthRequestExtraParams, "oidc-auth-request-extra-params", nil, "[authcode, authcode-keyboard, client-credentials] Extra query parameters to send with an authentication request")
+	f.StringVar(&o.AuthRequestAccessType, "oidc-auth-request-access-type", "offline", fmt.Sprintf("[authcode, authcode-keyboard] Access type to request. One of (%s). Set to online to request no refresh token", allAccessType))
 	f.StringVar(&o.Username, "username", "", "[password] Username for resource owner password credentials grant")
 	f.StringVar(&o.Password, "password", "", "[password] Password for resource owner password credentials grant")
 }
@@ -57,6 +64,11 @@ func (o *authenticationOptions) expandHomedir() {
 }
 
 func (o *authenticationOptions) grantOptionSet() (s authentication.GrantOptionSet, err error) {
+	switch o.AuthRequestAccessType {
+	case "offline", "online":
+	default:
+		return s, fmt.Errorf("oidc-auth-request-access-type must be one of (%s)", allAccessType)
+	}
 	switch {
 	case o.GrantType == "authcode" || (o.GrantType == "auto" && o.Username == ""):
 		s.AuthCodeBrowserOption = &authcode.BrowserOption{
@@ -68,10 +80,12 @@ func (o *authenticationOptions) grantOptionSet() (s authentication.GrantOptionSe
 			LocalServerKeyFile:         o.LocalServerKeyFile,
 			OpenURLAfterAuthentication: o.OpenURLAfterAuthentication,
 			AuthRequestExtraParams:     o.AuthRequestExtraParams,
+			AccessType:                 o.AuthRequestAccessType,
 		}
 	case o.GrantType == "authcode-keyboard":
 		s.AuthCodeKeyboardOption = &authcode.KeyboardOption{
 			AuthRequestExtraParams: o.AuthRequestExtraParams,
+			AccessType:             o.AuthRequestAccessType,
 		}
 	case o.GrantType == "password" || (o.GrantType == "auto" && o.Username != ""):
 		s.ROPCOption = &ropc.Option{

--- a/pkg/cmd/authentication_test.go
+++ b/pkg/cmd/authentication_test.go
@@ -22,6 +22,7 @@ func Test_authenticationOptions_grantOptionSet(t *testing.T) {
 				AuthCodeBrowserOption: &authcode.BrowserOption{
 					BindAddress:           defaultListenAddress,
 					AuthenticationTimeout: defaultAuthenticationTimeoutSec * time.Second,
+					AccessType:            "offline",
 				},
 			},
 		},
@@ -51,6 +52,20 @@ func Test_authenticationOptions_grantOptionSet(t *testing.T) {
 					LocalServerKeyFile:         "/path/to/local-server-key",
 					OpenURLAfterAuthentication: "https://example.com/success.html",
 					AuthRequestExtraParams:     map[string]string{"ttl": "86400", "reauth": "true"},
+					AccessType:                 "offline",
+				},
+			},
+		},
+		"AccessType=online": {
+			args: []string{
+				"--grant-type", "authcode",
+				"--oidc-auth-request-access-type", "online",
+			},
+			want: authentication.GrantOptionSet{
+				AuthCodeBrowserOption: &authcode.BrowserOption{
+					BindAddress:           defaultListenAddress,
+					AuthenticationTimeout: defaultAuthenticationTimeoutSec * time.Second,
+					AccessType:            "online",
 				},
 			},
 		},
@@ -59,7 +74,9 @@ func Test_authenticationOptions_grantOptionSet(t *testing.T) {
 				"--grant-type", "authcode-keyboard",
 			},
 			want: authentication.GrantOptionSet{
-				AuthCodeKeyboardOption: &authcode.KeyboardOption{},
+				AuthCodeKeyboardOption: &authcode.KeyboardOption{
+					AccessType: "offline",
+				},
 			},
 		},
 		"GrantType=authcode-keyboard with full options": {
@@ -71,6 +88,7 @@ func Test_authenticationOptions_grantOptionSet(t *testing.T) {
 			want: authentication.GrantOptionSet{
 				AuthCodeKeyboardOption: &authcode.KeyboardOption{
 					AuthRequestExtraParams: map[string]string{"ttl": "86400", "reauth": "true"},
+					AccessType:             "offline",
 				},
 			},
 		},
@@ -136,5 +154,17 @@ func Test_authenticationOptions_grantOptionSet(t *testing.T) {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func Test_authenticationOptions_grantOptionSet_invalidAccessType(t *testing.T) {
+	var o authenticationOptions
+	f := pflag.NewFlagSet("", pflag.ContinueOnError)
+	o.addFlags(f)
+	if err := f.Parse([]string{"--oidc-auth-request-access-type", "invalid"}); err != nil {
+		t.Fatalf("Parse error: %s", err)
+	}
+	if _, err := o.grantOptionSet(); err == nil {
+		t.Errorf("grantOptionSet wants an error but was nil")
 	}
 }

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -29,6 +29,7 @@ func TestCmd_Run(t *testing.T) {
 		AuthCodeBrowserOption: &authcode.BrowserOption{
 			BindAddress:           defaultListenAddress,
 			AuthenticationTimeout: defaultAuthenticationTimeoutSec * time.Second,
+			AccessType:            "offline",
 		},
 	}
 
@@ -191,6 +192,7 @@ func TestCmd_Run(t *testing.T) {
 						AuthCodeBrowserOption: &authcode.BrowserOption{
 							BindAddress:           defaultListenAddress,
 							AuthenticationTimeout: defaultAuthenticationTimeoutSec * time.Second,
+							AccessType:            "offline",
 							LocalServerCertFile:   filepath.Join(userHomeDir, ".kube/oidc-server.crt"),
 							LocalServerKeyFile:    filepath.Join(userHomeDir, ".kube/oidc-server.key"),
 						},

--- a/pkg/oidc/client/authcode.go
+++ b/pkg/oidc/client/authcode.go
@@ -17,6 +17,7 @@ type AuthCodeURLInput struct {
 	Nonce                  string
 	PKCEParams             pkce.Params
 	AuthRequestExtraParams map[string]string
+	AccessType             string
 }
 
 type ExchangeAuthCodeInput struct {
@@ -31,6 +32,7 @@ type GetTokenByAuthCodeInput struct {
 	Nonce                  string
 	PKCEParams             pkce.Params
 	AuthRequestExtraParams map[string]string
+	AccessType             string
 	LocalServerSuccessHTML string
 	LocalServerCertFile    string
 	LocalServerKeyFile     string
@@ -50,7 +52,7 @@ func (c *client) GetTokenByAuthCode(ctx context.Context, in GetTokenByAuthCodeIn
 	config := oauth2cli.Config{
 		OAuth2Config:            c.oauth2Config,
 		State:                   in.State,
-		AuthCodeOptions:         authorizationRequestOptions(in.Nonce, in.PKCEParams, in.AuthRequestExtraParams),
+		AuthCodeOptions:         authorizationRequestOptions(in.Nonce, in.PKCEParams, in.AuthRequestExtraParams, in.AccessType),
 		TokenRequestOptions:     tokenRequestOptions(in.PKCEParams),
 		LocalServerBindAddress:  in.BindAddress,
 		LocalServerReadyChan:    localServerReadyChan,
@@ -69,7 +71,7 @@ func (c *client) GetTokenByAuthCode(ctx context.Context, in GetTokenByAuthCodeIn
 
 // GetAuthCodeURL returns the URL of authentication request for the authorization code flow.
 func (c *client) GetAuthCodeURL(in AuthCodeURLInput) string {
-	opts := authorizationRequestOptions(in.Nonce, in.PKCEParams, in.AuthRequestExtraParams)
+	opts := authorizationRequestOptions(in.Nonce, in.PKCEParams, in.AuthRequestExtraParams, in.AccessType)
 	return c.oauth2Config.AuthCodeURL(in.State, opts...)
 }
 
@@ -84,9 +86,13 @@ func (c *client) ExchangeAuthCode(ctx context.Context, in ExchangeAuthCodeInput)
 	return c.verifyToken(ctx, token, in.Nonce)
 }
 
-func authorizationRequestOptions(nonce string, pkceParams pkce.Params, extraParams map[string]string) []oauth2.AuthCodeOption {
+func authorizationRequestOptions(nonce string, pkceParams pkce.Params, extraParams map[string]string, accessType string) []oauth2.AuthCodeOption {
+	accessTypeOption := oauth2.AccessTypeOffline
+	if accessType == "online" {
+		accessTypeOption = oauth2.AccessTypeOnline
+	}
 	opts := []oauth2.AuthCodeOption{
-		oauth2.AccessTypeOffline,
+		accessTypeOption,
 		gooidc.Nonce(nonce),
 	}
 	if pkceOpt := pkceParams.AuthCodeOption(); pkceOpt != nil {

--- a/pkg/oidc/client/authcode_test.go
+++ b/pkg/oidc/client/authcode_test.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/int128/kubelogin/pkg/pkce"
+	"golang.org/x/oauth2"
+)
+
+func Test_authorizationRequestOptions_accessType(t *testing.T) {
+	config := oauth2.Config{
+		ClientID: "YOUR_CLIENT_ID",
+		Endpoint: oauth2.Endpoint{AuthURL: "https://issuer.example.com/authorize"},
+	}
+	tests := map[string]string{
+		"":        "offline",
+		"offline": "offline",
+		"online":  "online",
+	}
+	for accessType, want := range tests {
+		t.Run("accessType="+accessType, func(t *testing.T) {
+			opts := authorizationRequestOptions("NONCE", pkce.Params{}, nil, accessType)
+			authCodeURL := config.AuthCodeURL("STATE", opts...)
+			u, err := url.Parse(authCodeURL)
+			if err != nil {
+				t.Fatalf("could not parse the authorization URL: %s", err)
+			}
+			if got := u.Query().Get("access_type"); got != want {
+				t.Errorf("access_type wants %s but was %s", want, got)
+			}
+		})
+	}
+}

--- a/pkg/usecases/authentication/authcode/browser.go
+++ b/pkg/usecases/authentication/authcode/browser.go
@@ -20,6 +20,7 @@ type BrowserOption struct {
 	AuthenticationTimeout      time.Duration
 	OpenURLAfterAuthentication string
 	AuthRequestExtraParams     map[string]string
+	AccessType                 string
 	LocalServerCertFile        string
 	LocalServerKeyFile         string
 }
@@ -54,6 +55,7 @@ func (u *Browser) Do(ctx context.Context, o *BrowserOption, oidcClient client.In
 		Nonce:                  nonce,
 		PKCEParams:             pkceParams,
 		AuthRequestExtraParams: o.AuthRequestExtraParams,
+		AccessType:             o.AccessType,
 		LocalServerSuccessHTML: successHTML,
 		LocalServerCertFile:    o.LocalServerCertFile,
 		LocalServerKeyFile:     o.LocalServerKeyFile,

--- a/pkg/usecases/authentication/authcode/keyboard.go
+++ b/pkg/usecases/authentication/authcode/keyboard.go
@@ -15,6 +15,7 @@ const keyboardPrompt = "Enter code: "
 
 type KeyboardOption struct {
 	AuthRequestExtraParams map[string]string
+	AccessType             string
 }
 
 // Keyboard provides the authorization code flow with keyboard interactive.
@@ -42,6 +43,7 @@ func (u *Keyboard) Do(ctx context.Context, o *KeyboardOption, oidcClient client.
 		Nonce:                  nonce,
 		PKCEParams:             pkceParams,
 		AuthRequestExtraParams: o.AuthRequestExtraParams,
+		AccessType:             o.AccessType,
 	})
 	u.Logger.Printf("Please visit the following URL in your browser: %s", authCodeURL)
 	code, err := u.Reader.ReadString(keyboardPrompt)


### PR DESCRIPTION
Fixes #1063.

By default kubelogin sends `access_type=offline` so the provider returns a refresh token. As mentioned in the issue you can already work around this with `--oidc-auth-request-extra-params=access_type=online`, but a dedicated flag reads better, so this adds one.

`--oidc-auth-request-access-type` takes `offline` (the default, no change in behavior) or `online`. With `online` no refresh token is requested, so kubelogin re-runs authentication once the ID token expires. It applies to the authcode and authcode-keyboard grants.

Added unit tests and a short note in docs/usage.md.
