### PR TITLE
Embed fixed version to draft release assets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
       contents: write
     steps:
       - id: create-draft-release
-        uses: int128/create-draft-release-action@b9bf1daffa8de33340bc2018d204722934951109 # v0.6.0
+        uses: int128/create-draft-release-action@f232d92906ec5d836edf04857b0ba445b08bac2c # v0.7.0
         with:
           dry-run: ${{ github.event_name == 'pull_request' }}
           body: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,13 +27,16 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 10
     outputs:
-      draft-release-name: ${{ steps.create-draft-release.outputs.draft-release-name }}
+      release-name: ${{ steps.create-draft-release.outputs.release-name }}
     permissions:
       contents: write
     steps:
-      - if: github.event_name == 'push'
-        id: create-draft-release
-        uses: int128/go-release-action/create-draft-release@9e1d6ec29fc6ffc2ba55f631baf4a73017d228e1 # v2.5.0
+      - id: create-draft-release
+        uses: int128/create-draft-release-action@b9bf1daffa8de33340bc2018d204722934951109 # v0.6.0
+        with:
+          dry-run: ${{ github.event_name == 'pull_request' }}
+          body: |
+            DO NOT RENAME this release. If you want to bump the minor version, push a new tag.
 
   build:
     needs: create
@@ -79,8 +82,10 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
-      - run: go build -ldflags "-X main.version=$GITHUB_SHA"
+      - run: go build -ldflags "-X main.version=$version"
+        env:
+          version: ${{ needs.create.outputs.release-name }}
       - uses: int128/go-release-action@9e1d6ec29fc6ffc2ba55f631baf4a73017d228e1 # v2.5.0
         with:
           binary: kubelogin
-          release-name: ${{ needs.create.outputs.draft-release-name }}
+          release-name: ${{ needs.create.outputs.release-name }}


### PR DESCRIPTION
## Issue
- https://github.com/int128/kubelogin/issues/1590
## Change
This changes the draft release name from `next` to the next patch version. It also changes the version of release assets from the commit SHA to the next version.
