### PR TITLE
Apply --authentication-timeout-sec to the device code flow

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -27,7 +27,7 @@ Flags:
       --listen-address strings                          [authcode] Address to bind to the local server. If multiple addresses are set, it will try binding in order (default [127.0.0.1:8000,127.0.0.1:18000])
       --skip-open-browser                               [authcode] Do not open the browser automatically
       --browser-command string                          [authcode] Command to open the browser
-      --authentication-timeout-sec int                  [authcode] Timeout of authentication in seconds (default 180)
+      --authentication-timeout-sec int                  [authcode, device-code] Timeout of authentication in seconds (default 180)
       --local-server-cert string                        [authcode] Certificate path for the local server
       --local-server-key string                         [authcode] Certificate key path for the local server
       --open-url-after-authentication string            [authcode] If set, open the URL in the browser after authentication
@@ -173,6 +173,9 @@ If you encounter a problem with the browser, you can change the browser command 
 # Do not open the browser
 - --skip-open-browser
 ```
+
+It waits for you to approve the device code for up to `--authentication-timeout-sec` (default 180 seconds), the same limit as the authorization code flow.
+If nobody approves in time, it gives up and releases the token cache lock so a later `kubectl` invocation is not blocked behind it.
 
 ### Authorization Code Flow
 

--- a/pkg/cmd/authentication.go
+++ b/pkg/cmd/authentication.go
@@ -42,7 +42,7 @@ func (o *authenticationOptions) addFlags(f *pflag.FlagSet) {
 	f.StringSliceVar(&o.ListenAddress, "listen-address", defaultListenAddress, "[authcode] Address to bind to the local server. If multiple addresses are set, it will try binding in order")
 	f.BoolVar(&o.SkipOpenBrowser, "skip-open-browser", false, "[authcode] Do not open the browser automatically")
 	f.StringVar(&o.BrowserCommand, "browser-command", "", "[authcode] Command to open the browser")
-	f.IntVar(&o.AuthenticationTimeoutSec, "authentication-timeout-sec", defaultAuthenticationTimeoutSec, "[authcode] Timeout of authentication in seconds")
+	f.IntVar(&o.AuthenticationTimeoutSec, "authentication-timeout-sec", defaultAuthenticationTimeoutSec, "[authcode, device-code] Timeout of authentication in seconds")
 	f.StringVar(&o.LocalServerCertFile, "local-server-cert", "", "[authcode] Certificate path for the local server")
 	f.StringVar(&o.LocalServerKeyFile, "local-server-key", "", "[authcode] Certificate key path for the local server")
 	f.StringVar(&o.OpenURLAfterAuthentication, "open-url-after-authentication", "", "[authcode] If set, open the URL in the browser after authentication")
@@ -80,8 +80,9 @@ func (o *authenticationOptions) grantOptionSet() (s authentication.GrantOptionSe
 		}
 	case o.GrantType == "device-code":
 		s.DeviceCodeOption = &devicecode.Option{
-			SkipOpenBrowser: o.SkipOpenBrowser,
-			BrowserCommand:  o.BrowserCommand,
+			SkipOpenBrowser:       o.SkipOpenBrowser,
+			BrowserCommand:        o.BrowserCommand,
+			AuthenticationTimeout: time.Duration(o.AuthenticationTimeoutSec) * time.Second,
 		}
 	case o.GrantType == "client-credentials":
 		endpointparams := make(map[string][]string, len(o.AuthRequestExtraParams))

--- a/pkg/usecases/authentication/devicecode/devicecode.go
+++ b/pkg/usecases/authentication/devicecode/devicecode.go
@@ -3,6 +3,7 @@ package devicecode
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/int128/kubelogin/pkg/infrastructure/browser"
 	"github.com/int128/kubelogin/pkg/infrastructure/logger"
@@ -11,8 +12,9 @@ import (
 )
 
 type Option struct {
-	SkipOpenBrowser bool
-	BrowserCommand  string
+	SkipOpenBrowser       bool
+	BrowserCommand        string
+	AuthenticationTimeout time.Duration
 }
 
 // DeviceCode provides the oauth2 device code flow.
@@ -27,6 +29,16 @@ func (u *DeviceCode) Do(ctx context.Context, in *Option, oidcClient client.Inter
 	authResponse, err := oidcClient.GetDeviceAuthorization(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("authorization error: %w", err)
+	}
+
+	// Bound the time we wait for the user to approve the device code.
+	// Without this, an unattended login polls the token endpoint until the
+	// authorization server expires the device code (if it ever does), and
+	// keeps the token cache lock held for all that time.
+	if in != nil && in.AuthenticationTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, in.AuthenticationTimeout)
+		defer cancel()
 	}
 
 	if authResponse.VerificationURIComplete != "" {

--- a/pkg/usecases/authentication/devicecode/devicecode_test.go
+++ b/pkg/usecases/authentication/devicecode/devicecode_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/int128/kubelogin/mocks/github.com/int128/kubelogin/pkg/infrastructure/browser_mock"
 	"github.com/int128/kubelogin/mocks/github.com/int128/kubelogin/pkg/oidc/client_mock"
@@ -182,4 +183,42 @@ func TestDeviceCode_openURL(t *testing.T) {
 		browserMock.EXPECT().OpenCommand(ctx, url, "test-command").Return(testError).Once()
 		deviceCode.openURL(ctx, &Option{BrowserCommand: "test-command"}, url)
 	})
+}
+
+func TestDeviceCode_AuthenticationTimeout(t *testing.T) {
+	ctx := context.TODO()
+	mockBrowser := browser_mock.NewMockInterface(t)
+	mockClient := client_mock.NewMockInterface(t)
+	dc := &DeviceCode{
+		Browser: mockBrowser,
+		Logger:  logger.New(t),
+	}
+	mockResponse := &oauth2dev.AuthorizationResponse{
+		DeviceCode:              "device-code-1",
+		VerificationURIComplete: "https://example.com/verificationComplete?code=code123",
+		ExpiresIn:               300,
+		Interval:                1,
+	}
+	mockClient.EXPECT().GetDeviceAuthorization(ctx).Return(mockResponse, nil).Once()
+	mockBrowser.EXPECT().Open("https://example.com/verificationComplete?code=code123").Return(nil).Once()
+	// Simulate a user who never approves: the poller only returns when the context is done.
+	mockClient.EXPECT().ExchangeDeviceCode(mock.Anything, mockResponse).
+		RunAndReturn(func(ctx context.Context, _ *oauth2dev.AuthorizationResponse) (*oidc.TokenSet, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}).Once()
+	done := make(chan struct{})
+	var err error
+	go func() {
+		defer close(done)
+		_, err = dc.Do(ctx, &Option{AuthenticationTimeout: 50 * time.Millisecond}, mockClient)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Do did not return within 5s; the authentication timeout was not applied")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("returned error is not context.DeadlineExceeded: %v", err)
+	}
 }


### PR DESCRIPTION
## Problem

The device code flow (`--grant-type=device-code`) has no client-side deadline. `devicecode.Do` calls `oauth2dev.PollToken`, which loops on `authorization_pending` until the context is cancelled or the server returns another error. Meanwhile `get_token.go` holds the exclusive flock on the token cache for the whole login.

So an unattended login (kubectl invoked from a script, a CI/agent step, or a terminal nobody is watching) lives until the authorization server expires the device code, and every subsequent `kubectl` call for the same cluster blocks on the lock behind it. Observed with authentik as the provider: four queued `kubelogin get-token` processes, the first polling for ~10 minutes, the next three waiting on the flock in `/proc/locks`, and every `kubectl` on the box appearing to hang.

The authorization code flow already bounds this with `--authentication-timeout-sec` (default 180s) via `context.WithTimeout` in `authcode/browser.go`. The device code flow just never got the same treatment.

## Change

- `devicecode.Option` gains `AuthenticationTimeout`; `Do` wraps the context with it after the device authorization request, so the deadline only covers the user-approval wait.
- `cmd/authentication.go` passes `--authentication-timeout-sec` through for `device-code`, and the flag help / `docs/usage.md` say `[authcode, device-code]`.
- A short note in the Device Authorization Grant section of `docs/usage.md`.
- Test: `TestDeviceCode_AuthenticationTimeout` simulates a user who never approves (`ExchangeDeviceCode` returns only on `ctx.Done()`) and asserts `Do` returns `context.DeadlineExceeded`.

A zero timeout leaves the context untouched, so existing callers constructing `Option{}` directly keep their current behaviour.

## Not in this PR

RFC 8628 §3.2 says the client should stop polling once `expires_in` from the device authorization response has elapsed. That belongs in `oauth2dev.PollToken` rather than here; happy to send that separately if you'd like it.
