### PR TITLE
Accept NumericDate values like described in RFC7519

### DIFF
--- a/pkg/jwt/decode.go
+++ b/pkg/jwt/decode.go
@@ -19,8 +19,8 @@ func DecodeWithoutVerify(s string) (*Claims, error) {
 		return nil, fmt.Errorf("could not decode the payload: %w", err)
 	}
 	var claims struct {
-		Subject   string `json:"sub,omitempty"`
-		ExpiresAt int64  `json:"exp,omitempty"`
+		Subject   string  `json:"sub,omitempty"`
+		ExpiresAt float64 `json:"exp,omitempty"`
 	}
 	if err := json.NewDecoder(bytes.NewReader(payload)).Decode(&claims); err != nil {
 		return nil, fmt.Errorf("could not decode the json of token: %w", err)
@@ -31,7 +31,7 @@ func DecodeWithoutVerify(s string) (*Claims, error) {
 	}
 	return &Claims{
 		Subject: claims.Subject,
-		Expiry:  time.Unix(claims.ExpiresAt, 0),
+		Expiry:  time.Unix(int64(claims.ExpiresAt), 0),
 		Pretty:  prettyJson.String(),
 	}, nil
 }

--- a/pkg/jwt/decode_test.go
+++ b/pkg/jwt/decode_test.go
@@ -33,6 +33,55 @@ func TestDecode(t *testing.T) {
 			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 	})
+	t.Run("ValidToken float expiry", func(t *testing.T) {
+		const (
+			// https://tools.ietf.org/html/rfc7519#section-3.1
+			header    = "eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9"
+			payload   = "eyJpc3MiOiJqb2UiLCJleHAiOjEzMDA4MTkzODAuMTMzNywiaHR0cDovL2V4YW1wbGUuY29tL2lzX3Jvb3QiOnRydWV9"
+			signature = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+			token     = header + "." + payload + "." + signature
+		)
+		got, err := DecodeWithoutVerify(token)
+		if err != nil {
+			t.Fatalf("Decode error: %s", err)
+		}
+		want := &Claims{
+			Subject: "",
+			Expiry:  time.Unix(1300819380, 0),
+			Pretty: `{
+  "iss": "joe",
+  "exp": 1300819380.1337,
+  "http://example.com/is_root": true
+}`,
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+	t.Run("ValidToken without expiry", func(t *testing.T) {
+		const (
+			// https://tools.ietf.org/html/rfc7519#section-3.1
+			header    = "eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9"
+			payload   = "eyJpc3MiOiJqb2UiLCJodHRwOi8vZXhhbXBsZS5jb20vaXNfcm9vdCI6dHJ1ZX0"
+			signature = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+			token     = header + "." + payload + "." + signature
+		)
+		got, err := DecodeWithoutVerify(token)
+		if err != nil {
+			t.Fatalf("Decode error: %s", err)
+		}
+		want := &Claims{
+			Subject: "",
+			Expiry:  time.Unix(0, 0),
+			Pretty: `{
+  "iss": "joe",
+  "http://example.com/is_root": true
+}`,
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
 
 	t.Run("InvalidToken", func(t *testing.T) {
 		decodedToken, err := DecodeWithoutVerify("HEADER.INVALID_TOKEN.SIGNATURE")


### PR DESCRIPTION
Hey there,

I found a bug in how id tokens are handled. Kubelogin has a validation step to check the expiry of a given jwt. This jwt must be compliant to RFC7519, and extracts the `sub` and `exp` claims in this process. (see pkg/jwt/decode.go)

The RFC describes the exp token like
> Its value MUST be a number containing a NumericDate value.

Where the explanation of the `NumericDate` type contains
> This is equivalent to the IEEE Std 1003.1, 2013 Edition [[POSIX.1](https://datatracker.ietf.org/doc/html/rfc7519#ref-POSIX.1)] definition "Seconds Since the Epoch", in which each day is accounted for by exactly 86400 seconds, **other than that non-integer values can be represented.**

In the current implementation though, the process fails with the following error:

```bash
> kubectl oidc-login setup --redacted-args --v 1
[irrelevant output]
I0909 10:45:52.976530   28876 browser.go:86] got a token set by the authorization code flow
I0909 10:45:52.976559   28876 browser.go:92] finished the authorization code flow via the browser
error: setup: you got an invalid token: could not decode the json of token: json: cannot unmarshal number 1788947152.811 into Go struct field .exp of type int64
I0909 10:45:52.976630   28876 cmd.go:69] stacktrace: setup: you got an invalid token: could not decode the json of token: json: cannot unmarshal number 1788947152.811 into Go struct field .exp of type int64
```

To fix this I converted the type used in decoding the JWT to be a `float64`, after which the value is directly converted to the `int64` needed by `time.Time`. Loss of precision in this instance seems fine to me! I also duplicated the `decode_test.go` ValidToken test to also validate missing/floating point values for the `exp` claim. 


AI Disclaimer: I used ChatGPT for finding the root cause and checking for existing issues/PR's, but all code in this PR is fully artisanal handwritten Go code. This PR description as well :)